### PR TITLE
Normalization and explicit substitutions

### DIFF
--- a/src/clj_lprolog/norm.clj
+++ b/src/clj_lprolog/norm.clj
@@ -1,59 +1,18 @@
 (ns clj-lprolog.norm
   "Kernel normalization"
   (:require [clj-lprolog.utils :as u :refer [example examples]]
-            [clj-lprolog.syntax :as syn]))
+            [clj-lprolog.syntax :as syn]
+            [clj-lprolog.typecheck :as typ]
+            [clojure.test :as t]))
 
 (def +examples-enabled+ true)
 
 ;;{
 ;; # Suspension calculus
 ;;
-;; Adapted from "Explicit Substitutions in the Reduction of Lambda",
+;; Adapted from "Explicit Substitutions in the Reduction of Lambda Terms",
 ;; Gopalan Nadathur and Xiaochu Qui, PPDP 2003
 ;;}
-
-(defn rewrite-suspension
-  "Apply the suspension rewriting rules. Assumes `s` is a suspension"
-  [s] (let [[t ol nl e] s]
-        (cond
-          ;; r1 : t is a constant
-          (syn/primitive? t) t
-          ;; r2 : t is an instantiatable variable
-          (syn/free? t) t
-          ;; r3 : i > ol and j = i - ol + nl
-          (and (syn/bound? t) (> (first t) ol))
-          #{(+ (- (first t) ol) nl)}
-          ;; r4 : i <= ol, e[i] = @l and j = nl - l
-          (and (syn/bound? t) (<= (first t) ol) (nat-int? (nth e (first t))))
-          #{(- nl (nth e (first t)))}
-          ;; r5 : i <= ol, e[i] = (t, l) and j = nl - l
-          (and (syn/bound? t) (<= (first t) ol) (vector? (nth e (first t))))
-          [(first (nth e (first t))) 0 (- nl (second (nth e (first t)))) '()]
-          ;; r6 : t is an application
-          (syn/application? t) (map (fn [t] [t ol nl e]) t)
-          ;; r7 : t is an abstraction
-          (syn/lambda? t)
-          (list 'λ (second t)
-                [(nth t 2) (+ ol (second t)) (+ nl (second t))
-                 (concat (reverse (take (second t) (iterate inc nl))) e)])
-          ;; r8 : t is a suspension
-          (and (syn/suspension? t) (zero? ol) (empty? e))
-          (let [[t ol nl' e] t] [t ol (+ nl nl') e])
-          ;; r9
-          (and (zero? ol) (zero? nl) (empty? e)) t)))
-
-(examples
- (rewrite-suspension ['(t1 t2) 'ol 'nl 'e]) => '([t1 ol nl e] [t2 ol nl e])
- (rewrite-suspension ['(λ 2 A) 1 1 '()]) => '(λ 2 [A 3 3 (2 1)]))
-
-(defn apply-suspensions
-  "Recursively apply all the suspensions left in `t`"
-  [t]
-  (cond
-    (syn/lambda? t) (list 'λ (second t) (apply-suspensions (nth t 2)))
-    (syn/application? t) (map apply-suspensions t)
-    (syn/suspension? t) (apply-suspensions (rewrite-suspension t))
-    :else t))
 
 (defn beta-step
   "Beta-reduce `t`, assuming it is a beta-redex"
@@ -63,15 +22,19 @@
         (let [hd (if (syn/suspension? (nth abs 2))
                    ;; if the body of the abstraction is already a suspension
                    (let [[t1 ol nl e] (nth abs 2)]
-                     [(syn/flatten-zero-lambda
-                       (list 'λ (dec (second abs)) t1))
+                     [(with-meta
+                        (syn/flatten-zero-lambda
+                         (list 'λ (dec (second abs)) t1))
+                        {:ty (second (syn/destruct-arrow (typ/type-of abs) 1))})
                       ol (dec nl) (cons [t2 (dec nl)] (rest e))])
                    ;; else
                    [(syn/flatten-zero-lambda
-                     (list 'λ (dec (second abs)) (nth abs 2)))
+                     (with-meta
+                       (list 'λ (dec (second abs)) (nth abs 2))
+                       {:ty (second (syn/destruct-arrow (typ/type-of abs) 1))}))
                     1 0 (list [t2 0])]
                    )]
-          (if (empty? tl) hd (cons hd tl)))))
+          (with-meta (if (empty? tl) hd (cons hd tl)) {:ty (typ/type-of t)}))))
 
 (examples
  (beta-step '((λ 1 #{0}) A)) => '[#{0} 1 0 ([A 0])]
@@ -79,15 +42,63 @@
  (beta-step '((λ 2 [A 2 3 (2 [#{0} 1])]) B C)) =>
  '([(λ 1 A) 2 2 ([B 2] [#{0} 1])] C))
 
+(defn rewrite-suspension
+  "Apply the suspension rewriting rules. Assumes `s` is a suspension"
+  [s] (let [[t ol nl e] s]
+        (with-meta
+          (cond
+            ;; r1 : t is a constant
+            (syn/primitive? t) t
+            ;; r2 : t is an instantiatable variable
+            (syn/free? t) t
+            ;; r3 : i > ol and j = i - ol + nl
+            (and (syn/bound? t) (> (first t) ol))
+            #{(+ (- (first t) ol) nl)}
+            ;; r4 : i <= ol, e[i] = @l and j = nl - l
+            (and (syn/bound? t) (<= (first t) ol) (nat-int? (nth e (first t))))
+            #{(- nl (nth e (first t)))}
+            ;; r5 : i <= ol, e[i] = (t, l) and j = nl - l
+            (and (syn/bound? t) (<= (first t) ol) (vector? (nth e (first t))))
+            [(first (nth e (first t))) 0 (- nl (second (nth e (first t)))) '()]
+            ;; r6 : t is an application
+            (syn/application? t) (map (fn [t] [t ol nl e]) t)
+            ;; r7 : t is an abstraction
+            (syn/lambda? t)
+            (list 'λ (second t)
+                  [(nth t 2) (+ ol (second t)) (+ nl (second t))
+                   (concat (reverse (take (second t) (iterate inc nl))) e)])
+            ;; r8 : t is a suspension
+            (and (syn/suspension? t) (zero? ol) (empty? e))
+            (let [[t ol nl' e] t] [t ol (+ nl nl') e])
+            ;; r9
+            (and (zero? ol) (zero? nl) (empty? e)) t)
+        {:ty (typ/type-of t)})))
+
+(examples
+ (rewrite-suspension ['(t1 t2) 'ol 'nl 'e]) => '([t1 ol nl e] [t2 ol nl e])
+ (rewrite-suspension ['(λ 2 A) 1 1 '()]) => '(λ 2 [A 3 3 (2 1)]))
+
+(defn apply-suspensions
+  "Recursively apply all the suspensions left in `t`"
+  [t]
+  (with-meta
+    (cond
+      (syn/lambda? t) (list 'λ (second t) (apply-suspensions (nth t 2)))
+      (syn/application? t) (map apply-suspensions t)
+      (syn/suspension? t) (apply-suspensions (rewrite-suspension t))
+      :else t) {:ty (typ/type-of t)}))
+
 (defn reduce
   "Fully beta reduce `t` using explicit substitutions"
-  [t] (loop [t t]
-        (cond
-          (syn/beta-redex? t) (recur (beta-step t))
-          ;; (syn/suspension? t) (recur (rewrite-suspension t))
-          (and (syn/application? t) (syn/suspension? (first t)))
-          (recur (cons (rewrite-suspension (first t)) (rest t)))
-          :else (apply-suspensions t))))
+  [t]
+  (loop [t t]
+    (cond
+      (syn/beta-redex? t) (recur (beta-step t))
+      (and (syn/application? t) (syn/suspension? (first t)))
+      (recur (with-meta
+               (cons (rewrite-suspension (first t)) (rest t))
+               {:ty (typ/type-of t)}))
+      :else (apply-suspensions t))))
 
 (examples
  (reduce '((λ 1 #{0}) A)) => 'A

--- a/src/clj_lprolog/norm.clj
+++ b/src/clj_lprolog/norm.clj
@@ -21,14 +21,14 @@
           ;; r2 : t is an instantiatable variable
           (syn/free? t) t
           ;; r3 : i > ol and j = i - ol + nl
-          (and (syn/bound? t) (> t ol))
-          (+ (- t ol) nl)
+          (and (syn/bound? t) (> (first t) ol))
+          #{(+ (- (first t) ol) nl)}
           ;; r4 : i <= ol, e[i] = @l and j = nl - l
-          (and (syn/bound? t) (<= t ol) (nat-int? (nth e t)))
-          (- nl (nth e t))
+          (and (syn/bound? t) (<= (first t) ol) (nat-int? (nth e (first t))))
+          #{(- nl (nth e (first t)))}
           ;; r5 : i <= ol, e[i] = (t, l) and j = nl - l
-          (and (syn/bound? t) (<= t ol) (vector? (nth e t)))
-          [(first (nth e t)) 0 (- nl (second (nth e t))) '()]
+          (and (syn/bound? t) (<= (first t) ol) (vector? (nth e (first t))))
+          [(first (nth e (first t))) 0 (- nl (second (nth e (first t)))) '()]
           ;; r6 : t is an application
           (syn/application? t) (map (fn [t] [t ol nl e]) t)
           ;; r7 : t is an abstraction
@@ -74,9 +74,10 @@
           (if (empty? tl) hd (cons hd tl)))))
 
 (examples
- (beta-step '((λ 1 0) A)) => '[0 1 0 ([A 0])]
- (beta-step '((λ 2 0) A B)) => '([(λ 1 0) 1 0 ([A 0])] B)
- (beta-step '((λ 2 [A 2 3 (2 [0 1])]) B C)) => '([(λ 1 A) 2 2 ([B 2] [0 1])] C))
+ (beta-step '((λ 1 #{0}) A)) => '[#{0} 1 0 ([A 0])]
+ (beta-step '((λ 2 #{0}) A B)) => '([(λ 1 #{0}) 1 0 ([A 0])] B)
+ (beta-step '((λ 2 [A 2 3 (2 [#{0} 1])]) B C)) =>
+ '([(λ 1 A) 2 2 ([B 2] [#{0} 1])] C))
 
 (defn reduce
   "Fully beta reduce `t` using explicit substitutions"
@@ -89,6 +90,6 @@
           :else (apply-suspensions t))))
 
 (examples
- (reduce '((λ 1 0) A)) => 'A
- (reduce '((λ 1 0) A B)) => '(A B)
- (reduce '((λ 2 0) A B)) => 'B)
+ (reduce '((λ 1 #{0}) A)) => 'A
+ (reduce '((λ 1 #{0}) A B)) => '(A B)
+ (reduce '((λ 2 #{0}) A B)) => 'B)

--- a/src/clj_lprolog/norm.clj
+++ b/src/clj_lprolog/norm.clj
@@ -90,7 +90,7 @@
 ;;}
 
 (defn implicit-subst
-  "Substitute `v` to the bound variable of index `n` in `t`"
+  "Substitute `v` to the bound variable of index `n` (default to 0) in `t`"
   ([v t] (implicit-subst 0 v t))
   ([n v t] (with-meta
             (cond
@@ -222,6 +222,12 @@
  (explicit-reduce '((λ 1 #{0}) A)) => 'A
  (explicit-reduce '((λ 1 #{0}) A B)) => '(A B)
  (explicit-reduce '((λ 2 #{0}) A B)) => 'B)
+
+;;{
+;; # Normalization
+;;
+;; Beta-reduce and eta-expand a term to get its head-normal form
+;;}
 
 (defn norm-beta
   "Beta-reduction part of the normalization of `t`"

--- a/src/clj_lprolog/norm.clj
+++ b/src/clj_lprolog/norm.clj
@@ -1,0 +1,85 @@
+(ns clj-lprolog.norm
+  "Kernel normalization"
+  (:require [clj-lprolog.utils :as u :refer [example examples]]
+            [clj-lprolog.syntax :as syn]))
+
+(def +examples-enabled+ true)
+
+;;{
+;; # Suspension calculus
+;;
+;; Adapted from "Explicit Substitutions in the Reduction of Lambda",
+;; Gopalan Nadathur and Xiaochu Qui, PPDP 2003
+;;}
+
+(defn rewrite-suspension
+  "Apply the suspension rewriting rules. Assumes `s` is a suspension"
+  [s] (let [[t ol nl e] s]
+        (cond
+          ;; r1 : t is a constant
+          (syn/primitive? t) t
+          ;; r2 : t is an instantiatable variable
+          (syn/free? t) t
+          ;; r3 : i > ol and j = i - ol + nl
+          (and (syn/bound? t) (> t ol))
+          (+ (- t ol) nl)
+          ;; r4 : i <= ol, e[i] = @l and j = nl - l
+          (and (syn/bound? t) (<= t ol) (nat-int? (nth e t)))
+          (- nl (nth e t))
+          ;; r5 : i <= ol, e[i] = (t, l) and j = nl - l
+          (and (syn/bound? t) (<= t ol) (vector? (nth e t)))
+          [(first (nth e t)) 0 (- nl (second (nth e t))) '()]
+          ;; r6 : t is an application
+          (syn/application? t) (map (fn [t] [t ol nl e]) t)
+          ;; r7 : t is an abstraction
+          (syn/lambda? t)
+          (list 'λ (second t)
+                [(nth t 2) (+ ol (second t)) (+ nl (second t))
+                 (concat (reverse (take (second t) (iterate inc nl))) e)])
+          ;; r8 : t is a suspension
+          (and (syn/suspension? t) (zero? ol) (empty? e))
+          (let [[t ol nl' e] t] [t ol (+ nl nl') e])
+          ;; r9
+          (and (zero? ol) (zero? nl) (empty? e)) t)))
+
+(examples
+ (rewrite-suspension ['(t1 t2) 'ol 'nl 'e]) => '([t1 ol nl e] [t2 ol nl e])
+ (rewrite-suspension ['(λ 2 A) 1 1 '()]) => '(λ 2 [A 3 3 (2 1)]))
+
+(defn beta-red
+  "Beta-reduce `t`, assuming it is a beta-redex"
+  [t] (let [abs (first t)
+            t2 (second t)
+            tl (nthrest t 2)]
+        (let [hd (if (syn/suspension? (nth abs 2))
+                   ;; if the body of the abstraction is already a suspension
+                   (let [[t1 ol nl e] (nth abs 2)]
+                     [(syn/flatten-zero-lambda
+                       (list 'λ (dec (second abs)) t1))
+                      ol (dec nl) (cons [t2 (dec nl)] (rest e))])
+                   ;; else
+                   [(syn/flatten-zero-lambda
+                     (list 'λ (dec (second abs)) (nth abs 2)))
+                    1 0 (list [t2 0])]
+                   )]
+          (if (empty? tl) hd (cons hd tl)))))
+
+(examples
+ (beta-red '((λ 1 0) A)) => '[0 1 0 ([A 0])]
+ (beta-red '((λ 2 0) A B)) => '([(λ 1 0) 1 0 ([A 0])] B)
+ (beta-red '((λ 2 [A 2 3 (2 [0 1])]) B C)) => '([(λ 1 A) 2 2 ([B 2] [0 1])] C))
+
+(defn reduce
+  "Fully beta reduce `t` using explicit substitutions"
+  [t] (loop [t t]
+        (cond
+          (syn/beta-redex? t) (recur (beta-red t))
+          (syn/suspension? t) (recur (rewrite-suspension t))
+          (and (syn/application? t) (syn/suspension? (first t)))
+          (recur (cons (rewrite-suspension (first t)) (rest t)))
+          :else t)))
+
+(examples
+ (reduce '((λ 1 0) A)) => 'A
+ (reduce '((λ 1 0) A B)) => '(A B)
+ (reduce '((λ 2 0) A B)) => 'B)

--- a/src/clj_lprolog/norm.clj
+++ b/src/clj_lprolog/norm.clj
@@ -168,7 +168,7 @@
             ;; r9
             (and (zero? ol) (zero? nl) (empty? e)) t
             ;; r1 : t is a constant
-            (syn/primitive? t) t
+            (or (syn/primitive? t) (syn/user-const? t)) t
             ;; r2 : t is an instantiatable variable
             (syn/free? t) t
             ;; r3 : i > ol and j = i - ol + nl

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -93,14 +93,6 @@
 
 (example (bound-or-const? 'x) => true)
 
-(defn free?
-  "Is `t` a free variable ?"
-  [t] (and (symbol? t)
-           (not (some #{t} syn/reserved))
-           (= (symbol (str/capitalize t)) t)))
-
-(example (free? 'X) => true)
-
 (defn lambda?
   "Is `t` a λ-abstraction ?"
   [t] (and (seq? t) (= (count t) 3)
@@ -112,7 +104,7 @@
 (defn user-term?
   "Is `t` a user term ?"
   [t] (or (bound-or-const? t)
-          (free? t)
+          (syn/free? t)
           (syn/primitive? t)
           (lambda? t)
           (syn/application? t)))
@@ -127,7 +119,7 @@
           ;; t is actually a use constant
           [:ok t])
 
-        (free? t) [:ok t]
+        (syn/free? t) [:ok t]
 
         (syn/primitive? t) [:ok t]
 

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -38,8 +38,8 @@
           (proper-lambda? t)
           (proper-application? t)))
 
-(example (proper-application? '((λ 2 0) A B)) => true)
-(example (proper-lambda? '(λ 2 0)) => true)
+(example (proper-application? '((λ 2 #{0}) A B)) => true)
+(example (proper-lambda? '(λ 2 #{0})) => true)
 
 ;;{
 ;; # Type syntax
@@ -130,7 +130,7 @@
   (cond (bound-or-const? t)
         (if (contains? (first env) t)
           ;; t is really a bound variable
-          [:ok (get (first env) t)]
+          [:ok #{(get (first env) t)}]
           ;; t is actually a use constant
           [:ok t])
 

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -103,18 +103,11 @@
 
 (defn lambda?
   "Is `t` a λ-abstraction ?"
-  [t] (and (seq? t)
+  [t] (and (seq? t) (= (count t) 3)
            (= (first t) 'λ)
            (vector? (second t)) (every? bound-or-const? (second t))))
 
 (example (lambda? '(λ [x y] (+ x y))) => true)
-
-(defn application?
-  "Is `t` an application ?"
-  [t] (and (seq? t)
-           (not (empty? t)) (not (empty? (rest t)))))
-
-(example (application? '(A B)) => true)
 
 (defn user-term?
   "Is `t` a user term ?"
@@ -122,7 +115,7 @@
           (free? t)
           (syn/primitive? t)
           (lambda? t)
-          (application? t)))
+          (syn/application? t)))
 
 (defn parse-aux
   "Parse a user term `t` to a kernel term using a naming environment"
@@ -148,7 +141,7 @@
                       env (second t))) :as [_ t']
         [:ok (list 'λ (count (second t)) t')])
 
-        (application? t)
+        (syn/application? t)
         (ok> (u/ok-map (fn [t] (parse-aux t env)) t) :as [_ t']
              [:ok (map (fn [[t]] t) t')])
 

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -23,9 +23,9 @@
 
 (defn bound?
   "Is `t` a bound variable ?"
-  [t] (nat-int? t))
+  [t] (and (set? t) (nat-int? (first t))))
 
-(example (bound? 1) => true)
+(example (bound? #{1}) => true)
 
 (defn free?
   "Is `t` a free variable ?"

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -50,22 +50,17 @@
 
 (defn lambda?
   "Is `t` a λ-abstraction ?"
-  [t] (and (seq? t)
+  [t] (and (seq? t) (= (count t) 3)
            (= (first t) 'λ)
            (nat-int? (second t))))
 
 (example (lambda? '(λ 2 (+ 1 0))) => true)
 
-(defn flatten-zero-lambda
-  "Transform `t`, a lambda into its body if the lambda abstract over 0 bindings.
-  Return unchanged `t` otherwise"
-  [t] (if (zero? (second t)) (nth t 2) t))
-
 (defn application?
   "Is `t` an application ?"
   [t] (and (seq? t)
            (not= (first t) 'λ)
-           (not (empty? t)) (not (empty? (rest t)))))
+           (not (empty? t))))
 
 (example (application? '(S O)) => true)
 

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -66,7 +66,8 @@
 
 (defn beta-redex?
   "Is `t` a beta-redex ?"
-  [t] (and (application? t) (lambda? (first t))))
+  [t] (and (application? t) (>= (count t) 2)
+           (lambda? (first t))))
 
 (defn suspension?
   "Is `t` a suspension ?"

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -56,12 +56,22 @@
 
 (example (lambda? '(λ 2 (+ 1 0))) => true)
 
+(defn flatten-zero-lambda
+  "Transform `t`, a lambda into its body if the lambda abstract over 0 bindings.
+  Return unchanged `t` otherwise"
+  [t] (if (zero? (second t)) (nth t 2) t))
+
 (defn application?
   "Is `t` an application ?"
   [t] (and (seq? t)
+           (not= (first t) 'λ)
            (not (empty? t)) (not (empty? (rest t)))))
 
 (example (application? '(S O)) => true)
+
+(defn beta-redex?
+  "Is `t` a beta-redex ?"
+  [t] (and (application? t) (lambda? (first t))))
 
 (defn suspension?
   "Is `t` a suspension ?"

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -14,6 +14,7 @@
 ;; - a constant (O, S, +, *, or user-declared)
 ;; - a n-ary λ-abstraction
 ;; - a n-ary application
+;; - a suspension (used for explicit substitutions)
 ;;}
 
 (def reserved
@@ -61,6 +62,15 @@
            (not (empty? t)) (not (empty? (rest t)))))
 
 (example (application? '(S O)) => true)
+
+(defn suspension?
+  "Is `t` a suspension ?"
+  [t] (and (vector? t) (= (count t) 4)
+           (nat-int? (nth t 1))
+           (nat-int? (nth t 2))
+           (seq? (nth t 3))))
+
+(example (suspension? ['(S O) 1 0 '()]) => true)
 
 ;;{
 ;; # Type syntax

--- a/src/clj_lprolog/typecheck.clj
+++ b/src/clj_lprolog/typecheck.clj
@@ -61,10 +61,15 @@
                            (not (or (type-unif-var? y1)
                                     (type-unif-var? y2))))))) s1))
 
+(defn apply-subst-subst
+  "Apply `s1` to every value of `s2`"
+  [s1 s2] (u/map-of-pair-list
+           (map (fn [[k ty]] [k (apply-subst-ty s1 ty)]) s2)))
+
 (defn compose-subst
   "Compose two substitutions `s1` and `s2`, after checking that they dont clash"
   [s1 s2] (ok> (when (subst-clash? s1 s2) [:ko> 'subst-clash {:s1 s1 :s2 s2}])
-               [:ok (conj s1 s2)]))
+               [:ok (conj s1 (apply-subst-subst s1 s2))]))
 
 (examples
  (compose-subst {'ty1 'i} {'ty2 'o}) =>
@@ -270,6 +275,7 @@
         (syn/application? t) (get (meta t) :ty)
         (syn/lambda? t) (get (meta t) :ty)
         (syn/suspension? t) (type-of (first t))))
+
 
 (defn apply-subst-env
   "Apply the type substitution `si` in the environment `e`"

--- a/src/clj_lprolog/typecheck.clj
+++ b/src/clj_lprolog/typecheck.clj
@@ -159,14 +159,20 @@
      ;; t is a bound variable
      (syn/bound? t)
      (ok>
-      (when (>= t (count env)) [:ko> 'outside-env {:n t :env env}])
-      [:ok {} (nth env t) t cnt])
+      (when (>= (first t) (count env))
+        [:ko> 'outside-env {:n (first t) :env env}])
+      (nth env (first t)) :as ty
+      [:ok {} ty (with-meta t {:ty ty}) cnt])
+
      ;; t is a free variable
      (syn/free? t) (let [ty (fresh-tvar cnt)]
                      [:ok {} ty (with-meta t {:ty ty}) (inc cnt)])
+
      ;; t is a primitive
      (syn/primitive? t)
-     (ok> [:ok {} (get primitive-env t) t cnt])
+     (ok> (get primitive-env t) :as ty
+          [:ok {} ty (with-meta t {:ty ty}) cnt])
+
      ;; t is a user constant
      (syn/user-const? t)
      (ok> (when (not (contains? consts t)) [:ko 'user-const {:const t}])
@@ -208,8 +214,7 @@
       [:ko 'type-infer-app {:t t}]
       (compose-subst si sihdtl) :as [_ si']
       [:ko 'type-infer-app {:t t}]
-      [:ok si' ty (with-meta (cons hd' tl') {:ty ty}) (inc cnt)]
-      ))))
+      [:ok si' ty (with-meta (cons hd' tl') {:ty ty}) (inc cnt)]))))
 
 (defn infer-term
   "Infer the type of `t`"
@@ -220,15 +225,14 @@
 
 (examples
  (infer-term '+) => [:ok '(-> i i i)]
- (infer-term '(λ 2 0)) => [:ok '(-> Ty0 Ty1 Ty1)]
- (infer-term '((λ 2 1) (λ 1 0))) => [:ok '(-> Ty1 (-> Ty2 Ty2))]
- (infer-term '((λ 1 0) (S O))) => [:ok 'i])
+ (infer-term '(λ 2 #{0})) => [:ok '(-> Ty0 Ty1 Ty1)]
+ (infer-term '((λ 2 #{1}) (λ 1 #{0}))) => [:ok '(-> Ty1 (-> Ty2 Ty2))]
+ (infer-term '((λ 1 #{0}) (S O))) => [:ok 'i])
 
 (defn apply-subst-metadata
   "Apply a substitution `si` in the metadata of `t`"
   [si t]
   (cond
-    (syn/bound? t) t
     (syn/lambda? t)
     (with-meta (list 'λ (second t) (apply-subst-metadata si (nth t 2)))
       {:ty (apply-subst-ty si (get (meta t) :ty))})
@@ -256,6 +260,16 @@
         [:ko 'check-term {:t t :ty ty}]
         (compose-subst si si2) :as [_ si]
         [:ok (apply-subst-metadata si t) cnt])))
+
+(defn type-of
+  "Retrieve type information for an elaborated term `t`"
+  [t] (cond
+        (syn/bound? t) (get (meta t) :ty)
+        (syn/free? t) (get (meta t) :ty)
+        (syn/primitive? t) (get (meta t) :ty)
+        (syn/application? t) (get (meta t) :ty)
+        (syn/lambda? t) (get (meta t) :ty)
+        (syn/suspension? t) (type-of (first t))))
 
 (defn apply-subst-env
   "Apply the type substitution `si` in the environment `e`"

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -3,29 +3,7 @@
             [clojure.test :as t]
             [clj-lprolog.typecheck :as typ]))
 
-(t/deftest rewrite-suspension-test
-  (t/is (= '([t1 ol nl e] [t2 ol nl e])
-           (nor/rewrite-suspension ['(t1 t2) 'ol 'nl 'e])))
-  (t/is (= '(λ 2 [A 3 3 (2 1)]) (nor/rewrite-suspension ['(λ 2 A) 1 1 '()]))))
-
-(t/deftest beta-step-test
-  (t/is (= '[0 1 0 ([A 0])] (nor/beta-step '((λ 1 0) A))))
-  (t/is (= '([(λ 1 #{0}) 1 0 ([A 0])] B)
-           (nor/beta-step '((λ 2 #{0}) A B))))
-  (t/is (= '([(λ 1 A) 2 2 ([B 2] [#{0} 1])] C)
-           (nor/beta-step '((λ 2 [A 2 3 (2 [#{0} 1])]) B C)))))
-
-(t/deftest beta-reduce-test
-  (t/is (= 'A (nor/reduce '((λ 1 #{0}) A))))
-  (t/is (= '(A B) (nor/reduce '((λ 1 #{0}) A B))))
-  (t/is (= 'B (nor/reduce '((λ 2 #{0}) A B))))
-  (t/is (= 'A (nor/reduce '((λ 2 #{1}) A B))))
-  (t/is (= '(A B) (nor/reduce '((λ 2 (#{1} #{0})) A B)))))
-
-(defn test-reduce-meta
-  [t] (binding [*print-meta* true]
-        (do (pr (nor/reduce (second (typ/elaborate-term t))))
-            (println ""))))
+;; Tests on syntax simplification
 
 (t/deftest flatten-lambda-test
   (t/is (= '(λ 3 #{0}) (nor/flatten-lambda '(λ 3 #{0}))))
@@ -44,5 +22,37 @@
   (t/is (= '(A B C D) (nor/flatten-application '(((A B) C) D))))
   (t/is (= '(A (B C) D) (nor/flatten-application '((A (B C)) D)))))
 
-;;(test-reduce-meta '((λ 2 (#{0} A)) A B))
+(t/deftest rewrite-suspension-test
+  (t/is (= '([t1 1 2 ()] [t2 1 2 ()])
+           (nor/rewrite-suspension ['(t1 t2) 1 2 ()])))
+  (t/is (= '(λ 2 [A 3 3 (2 1)]) (nor/rewrite-suspension ['(λ 2 A) 1 1 '()]))))
+
+;; Tests on explicit beta-reduction
+
+(t/deftest beta-step-test
+  (t/is (= '[#{0} 1 0 ([A 0])] (nor/beta-step '((λ 1 #{0}) A))))
+  (t/is (= '([(λ 1 #{0}) 1 0 ([A 0])] B)
+           (nor/beta-step '((λ 2 #{0}) A B))))
+  (t/is (= '([(λ 1 A) 2 2 ([B 2] [#{0} 1])] C)
+           (nor/beta-step '((λ 2 [A 2 3 (2 [#{0} 1])]) B C)))))
+
+(t/deftest beta-reduce-test
+  (t/is (= 'A (nor/explicit-reduce '((λ 1 #{0}) A))))
+  (t/is (= '(A B) (nor/explicit-reduce '((λ 1 #{0}) A B))))
+  (t/is (= 'B (nor/explicit-reduce '((λ 2 #{0}) A B))))
+  (t/is (= 'A (nor/explicit-reduce '((λ 2 #{1}) A B))))
+  (t/is (= '(A B) (nor/explicit-reduce '((λ 2 (#{1} #{0})) A B)))))
+
+(defn test-reduce-meta
+  [t] (binding [*print-meta* true]
+        (do (pr (nor/explicit-reduce (second (typ/elaborate-term t))))
+            (println ""))))
+
+(defn test-normalize-meta
+  [t] (binding [*print-meta* true]
+        (do (pr (nor/normalize (second (typ/elaborate-term t))))
+            (println ""))))
+
+;;(test-normalize-meta '((λ 2 (#{0} A)) A B))
+(test-normalize-meta '((λ 1 (λ 1 #{1})) (λ 3 (A #{0}))))
 ;;(test-reduce-meta '((λ 2 (λ 1 (#{0} A))) A B))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -1,0 +1,3 @@
+(ns clj-lprolog.norm-test
+  (:require [clj-lprolog.norm :as sut]
+            [clojure.test :as t]))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -59,6 +59,10 @@
 
 ;; Tests on normalization
 
+(t/deftest simplify-term-test
+  (t/is (= 'S (nor/simplify-term '(λ 0 (λ 0 S)))))
+  (t/is (= 'S (nor/simplify-term '(((((((((((((((((((S)))))))))))))))))))))))
+
 (t/deftest lift-indices-test
   (t/is (= #{2} (nor/lift-indices 2 #{0})))
   (t/is (= '(λ 1 #{0}) (nor/lift-indices 1 '(λ 1 #{0}))))
@@ -66,14 +70,15 @@
   (t/is (= '((λ 1 #{2}) #{1}) (nor/lift-indices 1 '((λ 1 #{1}) #{0})))))
 
 (defn eta
-  [t] (nor/norm-eta (second (typ/elaborate-term t))))
+  [t] (nor/norm-eta (second (typ/elaborate-term {} t))))
 
 (t/deftest norm-eta-test
   (t/is (= '(λ 2 #{0}) (eta '(λ 2 #{0}))))
+  (t/is (= '(λ 1 (S #{0})) (eta '(λ 0 S))))
   (t/is (= '(λ 3 ((λ 2 (S #{0})) #{1} #{0})) (eta '(λ 1 (λ 2 (S #{0})))))))
 
 (defn normalize
-  [t] (nor/normalize (second (typ/elaborate-term t))))
+  [t] (nor/normalize (second (typ/elaborate-term {} t))))
 
 (t/deftest normalize-test
   (t/is '(λ 0 (A)) (normalize '((λ 1 #{0}) A)))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -1,3 +1,22 @@
 (ns clj-lprolog.norm-test
-  (:require [clj-lprolog.norm :as sut]
+  (:require [clj-lprolog.norm :as nor]
             [clojure.test :as t]))
+
+(t/deftest rewrite-suspension-test
+  (t/is (= '([t1 ol nl e] [t2 ol nl e])
+           (nor/rewrite-suspension ['(t1 t2) 'ol 'nl 'e])))
+  (t/is (= '(λ 2 [A 3 3 (2 1)]) (nor/rewrite-suspension ['(λ 2 A) 1 1 '()]))))
+
+(t/deftest beta-step-test
+  (t/is (= '[0 1 0 ([A 0])] (nor/beta-step '((λ 1 0) A))))
+  (t/is (= '([(λ 1 0) 1 0 ([A 0])] B)
+           (nor/beta-step '((λ 2 0) A B))))
+  (t/is (= '([(λ 1 A) 2 2 ([B 2] [0 1])] C)
+           (nor/beta-step '((λ 2 [A 2 3 (2 [0 1])]) B C)))))
+
+(t/deftest beta-reduce-test
+  (t/is (= 'A (nor/reduce '((λ 1 0) A))))
+  (t/is (= '(A B) (nor/reduce '((λ 1 0) A B))))
+  (t/is (= 'B (nor/reduce '((λ 2 0) A B))))
+  (t/is (= 'A (nor/reduce '((λ 2 1) A B))))
+  (t/is (= '(A B) (nor/reduce '((λ 2 (1 0)) A B)))))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -1,6 +1,7 @@
 (ns clj-lprolog.norm-test
   (:require [clj-lprolog.norm :as nor]
-            [clojure.test :as t]))
+            [clojure.test :as t]
+            [clj-lprolog.typecheck :as typ]))
 
 (t/deftest rewrite-suspension-test
   (t/is (= '([t1 ol nl e] [t2 ol nl e])
@@ -20,3 +21,11 @@
   (t/is (= 'B (nor/reduce '((λ 2 #{0}) A B))))
   (t/is (= 'A (nor/reduce '((λ 2 #{1}) A B))))
   (t/is (= '(A B) (nor/reduce '((λ 2 (#{1} #{0})) A B)))))
+
+(defn test-reduce-meta
+  [t] (binding [*print-meta* true]
+        (do (pr (nor/reduce (second (typ/elaborate-term t))))
+            (println ""))))
+
+;;(test-reduce-meta '((λ 2 (#{0} A)) A B))
+;;(test-reduce-meta '((λ 2 (λ 1 (#{0} A))) A B))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -27,6 +27,20 @@
            (nor/rewrite-suspension ['(t1 t2) 1 2 ()])))
   (t/is (= '(λ 2 [A 3 3 (2 1)]) (nor/rewrite-suspension ['(λ 2 A) 1 1 '()]))))
 
+;; Tests on implicit beta-reduction
+
+(t/deftest implicit-subst-test
+  (t/is (= '(S O) (nor/implicit-subst 2 'O '(S #{2}))))
+  (t/is (= '((λ 1 #{0}) A) (nor/implicit-subst 'A '((λ 1 #{0}) #{0}))))
+  (t/is (= '((λ 1 A) A) (nor/implicit-subst 'A '((λ 1 #{1}) #{0}))))
+  (t/is (= '((λ 1 #{1}) A) (nor/implicit-subst 1 'A '((λ 1 #{1}) #{1})))))
+
+(t/deftest implicit-reduce-test
+  (t/is (= '(S O) (nor/implicit-reduce '((λ 1 (S #{0})) O))))
+  (t/is (= '(A B) (nor/implicit-reduce '((λ 2 (#{0} #{1})) B A))))
+  (t/is (= '(λ 1 (#{0} B)) (nor/implicit-reduce '((λ 2 (#{0} #{1})) B))))
+  (t/is (= 'A (nor/implicit-reduce '((λ 1 (#{0} A)) (λ 1 #{0}))))))
+
 ;; Tests on explicit beta-reduction
 
 (t/deftest beta-step-test
@@ -36,23 +50,40 @@
   (t/is (= '([(λ 1 A) 2 2 ([B 2] [#{0} 1])] C)
            (nor/beta-step '((λ 2 [A 2 3 (2 [#{0} 1])]) B C)))))
 
-(t/deftest beta-reduce-test
+(t/deftest explicit-beta-reduce-test
   (t/is (= 'A (nor/explicit-reduce '((λ 1 #{0}) A))))
   (t/is (= '(A B) (nor/explicit-reduce '((λ 1 #{0}) A B))))
   (t/is (= 'B (nor/explicit-reduce '((λ 2 #{0}) A B))))
   (t/is (= 'A (nor/explicit-reduce '((λ 2 #{1}) A B))))
   (t/is (= '(A B) (nor/explicit-reduce '((λ 2 (#{1} #{0})) A B)))))
 
-(defn test-reduce-meta
-  [t] (binding [*print-meta* true]
-        (do (pr (nor/explicit-reduce (second (typ/elaborate-term t))))
-            (println ""))))
+;; Tests on normalization
+
+(t/deftest lift-indices-test
+  (t/is (= #{2} (nor/lift-indices 2 #{0})))
+  (t/is (= '(λ 1 #{0}) (nor/lift-indices 1 '(λ 1 #{0}))))
+  (t/is (= '(λ 1 #{3}) (nor/lift-indices 2 '(λ 1 #{1}))))
+  (t/is (= '((λ 1 #{2}) #{1}) (nor/lift-indices 1 '((λ 1 #{1}) #{0})))))
+
+(defn eta
+  [t] (nor/norm-eta (second (typ/elaborate-term t))))
+
+(t/deftest norm-eta-test
+  (t/is (= '(λ 2 #{0}) (eta '(λ 2 #{0}))))
+  (t/is (= '(λ 3 ((λ 2 (S #{0})) #{1} #{0})) (eta '(λ 1 (λ 2 (S #{0})))))))
+
+(defn normalize
+  [t] (nor/normalize (second (typ/elaborate-term t))))
+
+(t/deftest normalize-test
+  (t/is '(λ 0 (A)) (normalize '((λ 1 #{0}) A)))
+  (t/is (= '(λ 2 (A #{0})) (normalize '((λ 1 (λ 1 #{1})) (λ 1 (A #{0})))))))
 
 (defn test-normalize-meta
   [t] (binding [*print-meta* true]
-        (do (pr (nor/normalize (second (typ/elaborate-term t))))
+        (do (pr (normalize t))
             (println ""))))
 
 ;;(test-normalize-meta '((λ 2 (#{0} A)) A B))
-(test-normalize-meta '((λ 1 (λ 1 #{1})) (λ 3 (A #{0}))))
+;;(test-normalize-meta '((λ 1 (λ 1 #{1})) (λ 3 (A #{0}))))
 ;;(test-reduce-meta '((λ 2 (λ 1 (#{0} A))) A B))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -9,14 +9,14 @@
 
 (t/deftest beta-step-test
   (t/is (= '[0 1 0 ([A 0])] (nor/beta-step '((λ 1 0) A))))
-  (t/is (= '([(λ 1 0) 1 0 ([A 0])] B)
-           (nor/beta-step '((λ 2 0) A B))))
-  (t/is (= '([(λ 1 A) 2 2 ([B 2] [0 1])] C)
-           (nor/beta-step '((λ 2 [A 2 3 (2 [0 1])]) B C)))))
+  (t/is (= '([(λ 1 #{0}) 1 0 ([A 0])] B)
+           (nor/beta-step '((λ 2 #{0}) A B))))
+  (t/is (= '([(λ 1 A) 2 2 ([B 2] [#{0} 1])] C)
+           (nor/beta-step '((λ 2 [A 2 3 (2 [#{0} 1])]) B C)))))
 
 (t/deftest beta-reduce-test
-  (t/is (= 'A (nor/reduce '((λ 1 0) A))))
-  (t/is (= '(A B) (nor/reduce '((λ 1 0) A B))))
-  (t/is (= 'B (nor/reduce '((λ 2 0) A B))))
-  (t/is (= 'A (nor/reduce '((λ 2 1) A B))))
-  (t/is (= '(A B) (nor/reduce '((λ 2 (1 0)) A B)))))
+  (t/is (= 'A (nor/reduce '((λ 1 #{0}) A))))
+  (t/is (= '(A B) (nor/reduce '((λ 1 #{0}) A B))))
+  (t/is (= 'B (nor/reduce '((λ 2 #{0}) A B))))
+  (t/is (= 'A (nor/reduce '((λ 2 #{1}) A B))))
+  (t/is (= '(A B) (nor/reduce '((λ 2 (#{1} #{0})) A B)))))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -27,5 +27,22 @@
         (do (pr (nor/reduce (second (typ/elaborate-term t))))
             (println ""))))
 
+(t/deftest flatten-lambda-test
+  (t/is (= '(λ 3 #{0}) (nor/flatten-lambda '(λ 3 #{0}))))
+  (t/is (= '(λ 3 #{0}) (nor/flatten-lambda '(λ 1 (λ 1 (λ 1 #{0})))))))
+
+(t/deftest flatten-zero-lambda-test
+  (t/is (= '(A B) (nor/flatten-zero-lambda '(λ 0 (A B)))))
+  (t/is (= '(λ 1 (A B)) (nor/flatten-zero-lambda '(λ 1 (A B))))))
+
+(t/deftest lambda-form-test
+  (t/is (= '(λ 0 A) (nor/lambda-form 'A)))
+  (t/is (= '(λ 1 A) (nor/lambda-form '(λ 1 A)))))
+
+(t/deftest flatten-application-test
+  (t/is (= '(A B C) (nor/flatten-application '((A B) C))))
+  (t/is (= '(A B C D) (nor/flatten-application '(((A B) C) D))))
+  (t/is (= '(A (B C) D) (nor/flatten-application '((A (B C)) D)))))
+
 ;;(test-reduce-meta '((λ 2 (#{0} A)) A B))
 ;;(test-reduce-meta '((λ 2 (λ 1 (#{0} A))) A B))

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -25,6 +25,7 @@
 (t/deftest rewrite-suspension-test
   (t/is (= '([t1 1 2 ()] [t2 1 2 ()])
            (nor/rewrite-suspension ['(t1 t2) 1 2 ()])))
+  (t/is (= 'succ (nor/rewrite-suspension ['succ 1 2 ()])))
   (t/is (= '(λ 2 [A 3 3 (2 1)]) (nor/rewrite-suspension ['(λ 2 A) 1 1 '()]))))
 
 ;; Tests on implicit beta-reduction

--- a/test/clj_lprolog/presyntax_test.clj
+++ b/test/clj_lprolog/presyntax_test.clj
@@ -18,7 +18,6 @@
     (t/is (syn/proper-application? '(A #{1} #{2}))))
   (t/testing "negative"
     (t/is (not (syn/proper-application? '())))
-    (t/is (not (syn/proper-application? '(A))))
     (t/is (not (syn/proper-application? '(A ()))))))
 
 (t/deftest proper-kernel-term?-test
@@ -74,13 +73,6 @@
   (t/testing "negative"
     (t/is (not (syn/lambda? '(l [x y] 1))))
     (t/is (not (syn/lambda? '(λ 1 x))))))
-
-(t/deftest application?-test
-  (t/testing "positive"
-    (t/is (syn/application? '(A x y))))
-  (t/testing "negative"
-    (t/is (not (syn/application? '())))
-    (t/is (not (syn/application? '(A))))))
 
 (t/deftest parse-test
   (t/testing "successful parsing"

--- a/test/clj_lprolog/presyntax_test.clj
+++ b/test/clj_lprolog/presyntax_test.clj
@@ -59,14 +59,6 @@
     (t/is (not (syn/bound-or-const? ())))
     (t/is (not (syn/bound-or-const? -1)))))
 
-(t/deftest free?-test
-  (t/testing "positive"
-    (t/is (syn/free? 'A)))
-  (t/testing "negative"
-    (t/is (not (syn/free? 'O)))
-    (t/is (not (syn/free? 'a)))
-    (t/is (not (syn/free? ())))))
-
 (t/deftest lambda?-test
   (t/testing "positive"
     (t/is (syn/lambda? '(λ [x y] x))))

--- a/test/clj_lprolog/syntax_test.clj
+++ b/test/clj_lprolog/syntax_test.clj
@@ -42,6 +42,19 @@
   (t/testing "negative"
     (t/is (not (syn/user-const? 'A)))))
 
+(t/deftest lambda?-test
+  (t/testing "positive"
+    (t/is (syn/lambda? '(λ 2 #{0}))))
+  (t/testing "negative"
+    (t/is (not (syn/lambda? '(λ [x y] #{0}))))
+    (t/is (not (syn/lambda? '(λ 2))))))
+
+(t/deftest application?-test
+  (t/testing "positive"
+    (t/is (syn/application? '(A #{0} #{1}))))
+  (t/testing "negative"
+    (t/is (not (syn/application? '())))))
+
 ;; Tests on type syntax
 
 (t/deftest type-var?-test

--- a/test/clj_lprolog/syntax_test.clj
+++ b/test/clj_lprolog/syntax_test.clj
@@ -13,11 +13,11 @@
 
 (t/deftest bound?-test
   (t/testing "positive"
-    (t/is (syn/bound? 42)))
+    (t/is (syn/bound? #{42})))
   (t/testing "negative"
     (t/is (not (syn/bound? 'A)))
     (t/is (not (syn/bound? ())))
-    (t/is (not (syn/bound? -1)))))
+    (t/is (not (syn/bound? #{-1})))))
 
 (t/deftest free?-test
   (t/testing "positive"

--- a/test/clj_lprolog/typecheck_test.clj
+++ b/test/clj_lprolog/typecheck_test.clj
@@ -38,28 +38,28 @@
 
 (t/deftest infer-term-test
   (t/testing "positive"
-    (t/is (u/ok-expr? (typ/subst-infer-term {} 0 ['i] 0)))
+    (t/is (u/ok-expr? (typ/subst-infer-term {} #{0} ['i] 0)))
     (t/is (= [:ok 'i] (typ/infer-term '(S (S (S O))))))
     (t/is (= [:ok 'nat] (typ/infer-term {'zero 'nat} 'zero)))
     (t/is (= [:ok 'nat] (typ/infer-term {'succ '(-> nat nat)} '(succ N))))
     (t/is (= [:ok '(-> i i)] (typ/infer-term '(+ (* (S O) (S O))))))
-    (t/is (u/ok-expr? (typ/infer-term '(λ 1 0))))
-    (t/is (u/ok-expr? (typ/infer-term '(λ 2 1))))
-    (t/is (u/ok-expr? (typ/infer-term '((λ 2 1) O))))
-    (t/is (= [:ok '(-> i i)] (typ/infer-term '((λ 2 (+ 0 1)) O))))
+    (t/is (u/ok-expr? (typ/infer-term '(λ 1 #{0}))))
+    (t/is (u/ok-expr? (typ/infer-term '(λ 2 #{1}))))
+    (t/is (u/ok-expr? (typ/infer-term '((λ 2 #{1}) O))))
+    (t/is (= [:ok '(-> i i)] (typ/infer-term '((λ 2 (+ #{0} #{1})) O))))
     (t/is (= [:ok 'i] (typ/infer-term '(λ 0 (S O))))))
   (t/testing "negative"
     (t/is (u/ko-expr? (typ/infer-term '(S S))))
-    (t/is (u/ko-expr? (typ/infer-term '((λ 1 (+ 0 0)) S))))))
+    (t/is (u/ko-expr? (typ/infer-term '((λ 1 (+ #{0} #{0})) S))))))
 
 (t/deftest check-and-elaborate-term-test
   (t/testing "positive"
     (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '(S (S (S O))) 'i)))
-    (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '(λ 1 0) '(-> a a))))
-    (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '(λ 2 1) '(-> a b a))))
-    (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '((λ 2 1) O) '(-> a i)))))
+    (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '(λ 1 #{0}) '(-> A A))))
+    (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '(λ 2 #{1}) '(-> A i A))))
+    (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '((λ 2 #{1}) O) '(-> A i)))))
   (t/testing "negative"
-    (t/is (u/ko-expr? (typ/check-and-elaborate-term {} '(λ 1 0) '(-> a b))))))
+    (t/is (u/ko-expr? (typ/check-and-elaborate-term {} '(λ 1 #{0}) '(-> A B))))))
 
 ;; Not easy to test metadata simply...
 
@@ -82,9 +82,10 @@
   (t/testing "positive"
     (t/is (= [:ok {'A 'o}] (elab-and-freevars '(λ 1 A) '(-> i o))))
     (t/is (= [:ok {'A 'i}] (elab-and-freevars '((λ 1 A) A) 'i)))
-    (t/is (= [:ok {'A 'i 'B 'i}] (elab-and-freevars '((λ 2 (+ 0 1)) A B) 'i))))
+    (t/is (= [:ok {'A 'i 'B 'i}]
+             (elab-and-freevars '((λ 2 (+ #{0} #{1})) A B) 'i))))
   (t/testing "negative"
-    (t/is (u/ko-expr? (elab-and-freevars '((λ 1 (+ (A O) 0)) A) 'i)))))
+    (t/is (u/ko-expr? (elab-and-freevars '((λ 1 (+ (A O) #{0})) A) 'i)))))
 
 (t/deftest check-pred-test
   (t/testing "even"

--- a/test/clj_lprolog/typecheck_test.clj
+++ b/test/clj_lprolog/typecheck_test.clj
@@ -52,6 +52,11 @@
     (t/is (u/ko-expr? (typ/infer-term '(S S))))
     (t/is (u/ko-expr? (typ/infer-term '((λ 1 (+ #{0} #{0})) S))))))
 
+(t/deftest elaborate-term-test
+  (t/testing "elaborated terms stay the same"
+    (t/is (= '((λ 2 #{0}) A B)
+             (second (typ/elaborate-term '((λ 2 #{0}) A B)))))))
+
 (t/deftest check-and-elaborate-term-test
   (t/testing "positive"
     (t/is (u/ok-expr? (typ/check-and-elaborate-term {} '(S (S (S O))) 'i)))

--- a/test/clj_lprolog/typecheck_test.clj
+++ b/test/clj_lprolog/typecheck_test.clj
@@ -55,7 +55,7 @@
 (t/deftest elaborate-term-test
   (t/testing "elaborated terms stay the same"
     (t/is (= '((λ 2 #{0}) A B)
-             (second (typ/elaborate-term '((λ 2 #{0}) A B)))))))
+             (second (typ/elaborate-term {} '((λ 2 #{0}) A B)))))))
 
 (t/deftest check-and-elaborate-term-test
   (t/testing "positive"


### PR DESCRIPTION
Je suis en train d'implémenter une beta-reduction (et a terme normalisation) avec substitutions explicites, en suivant *Explicit Substitutions in the Reduction of Lambda Terms*, Gopalan Nadathur and Xiaochu Qui, PPDP 2003

Ca se passe plutot bien, mais il reste quelques petites choses à régler:
1. Il faudrait que la réduction préserve les informations de types collectées lors de l'élaboration. Ce n'est pas difficile à faire, mais j'ai peur que cela rende le code un peu moins clair...
2. Je ne suis pas complètement sur de comment faire l'eta-expansion (mais je devrai pouvoir trouver)

De plus, je n'ai pas encore écrit beaucoup de tests unitaires. Ce serait bien si quelqu'un d'autre que moi les écrivait (quelqu'un qui a lu l'article mentionné plus haut par exemple), parce que moi on m'a toujours dit que ça ne devait pas être celui qui écrit le code qui écrit les tests :stuck_out_tongue: 