### PR TITLE
Builtins

### DIFF
--- a/samples/clj_lprolog/pcf/eval.clj
+++ b/samples/clj_lprolog/pcf/eval.clj
@@ -1,0 +1,54 @@
+(ns clj-lprolog.pcf.eval
+  (:require [clj-lprolog.core :as lp]))
+
+(load-file "samples/clj_lprolog/pcf/pcf.clj")
+
+;;{
+;; Call-by-value interpreter for PCF
+;;}
+
+(lp/defpred 'is '(-> tm tm o))
+(lp/defpred 'eval '(-> tm tm o))
+
+(lp/addclause '((is X X)))
+
+(lp/addclause '((eval (abs R) (abs R))))
+(lp/addclause '((eval (app M N) V) :- (eval M (abs R)) (eval (R N) V)))
+(lp/addclause '((eval (fixpt R) V) :- (eval (R (fixpt R)) V)))
+(lp/addclause '((eval (cond C T E) V) :-
+                (eval C X) (is X (ib true)) (eval T V)))
+(lp/addclause '((eval (cond C T E) V) :-
+                (eval C X) (is X (ib false)) (eval E V)))
+
+;; Bool primitives
+(lp/addclause '((eval (ib B) (ib B))))
+(lp/addclause '((eval (app (app && B1) B2) (ib (and V1 V2))) :-
+                (eval B1 (ib V1)) (eval B2 (ib V2))))
+(lp/addclause '((eval (app (app || B1) B2) (ib (or V1 V2))) :-
+                (eval B1 (ib V1)) (eval B2 (ib V2))))
+
+;; Num primitives
+(lp/addclause '((eval (in N) (in N))))
+(lp/addclause '((eval (app (app plus N1) N2) (in (+ V1 V2))) :-
+                (eval N1 (in V1)) (eval N2 (in V2))))
+(lp/addclause '((eval (app (app minus N1) N2) (in (- V1 V2))) :-
+                (eval N1 (in V1)) (eval N2 (in V2))))
+(lp/addclause '((eval (app (app times N1) N2) (in (* V1 V2))) :-
+                (eval N1 (in V1)) (eval N2 (in V2))))
+(lp/addclause '((eval (app (app equal E1) E2) (ib (= V1 V2))) :-
+                (eval E1 (in V1)) (eval E2 (in V2))))
+(lp/addclause '((eval (app (app greater E1) E2) (ib (> V1 V2))) :-
+                (eval E1 (in V1)) (eval E2 (in V2))))
+(lp/addclause '((eval (app zerop N1) (ib (zero? V1))) :-
+                (eval N1 (in V1))))
+
+;; List primitives
+(lp/addclause '((eval ni ni)))
+(lp/addclause '((eval (app (app cs E1) E2) (app (app cs V1) V2)) :-
+                (eval E1 V1) (eval E2 V2)))
+(lp/addclause '((eval (app car E) X) :- (eval E (app (app cs X) Y))))
+(lp/addclause '((eval (app cdr E) Y) :- (eval E (app (app cs X) Y))))
+(lp/addclause '((eval (app nullp E) (ib true)) :- (eval E ni)))
+(lp/addclause '((eval (app nullp E) (ib false)) :- (eval E (app (app cs X) Y))))
+(lp/addclause '((eval (app consp E) (ib false)) :- (eval E ni)))
+(lp/addclause '((eval (app consp E) (ib true)) :- (eval E (app (app cs X) Y))))

--- a/samples/clj_lprolog/pcf/eval_test.clj
+++ b/samples/clj_lprolog/pcf/eval_test.clj
@@ -1,0 +1,25 @@
+(ns clj-lprolog.pcf.eval-test
+  (:require [clj-lprolog.core :as lp]))
+
+(load-file "samples/clj_lprolog/pcf/eval.clj")
+(load-file "samples/clj_lprolog/pcf/examples.clj")
+
+(lp/defpred 'eval-test '(-> int tm o))
+
+(lp/addclause '((eval-test 1 V) :-
+                (prog "successor" Suc), (eval (app Suc (in 12)) V)))
+
+(lp/addclause '((eval-test 2 V) :-
+                (prog "fib" Fib), (eval (app Fib (in 4)) V)))
+
+(lp/addclause '((eval-test 3 V) :-
+                (prog "fact" Fact), (eval (app (app Fact (in 4)) (in 1)) V)))
+
+(lp/addclause '((eval-test 4 V) :- (prog "map" Map) (prog "successor" Succ)
+                (eval (app (app Map Succ) (app (app cs (in 1))
+                                               (app (app cs (in 41)) ni))) V)))
+
+;;(lp/solve '(eval-test 1 V))
+;;(lp/solve '(eval-test 2 V)) ;; This is very long
+;;(lp/solve '(eval-test 3 V))
+(lp/solve '(eval-test 4 V))

--- a/samples/clj_lprolog/pcf/examples.clj
+++ b/samples/clj_lprolog/pcf/examples.clj
@@ -1,0 +1,61 @@
+(ns clj-lprolog.pcf.examples
+  (:require [clj-lprolog.core :as lp]))
+
+(load-file "samples/clj_lprolog/pcf/pcf.clj")
+
+(lp/defpred 'prog '(-> string tm o))
+
+;; Successor function
+(lp/addclause '((prog "successor"
+                      (abs (λ [x] (app (app plus x) (in 1)))))))
+
+;; If the first argument is equal to 1, return the second, and the third otherwise
+(lp/addclause
+ '((prog "onep"
+         (abs (λ [w] (abs (λ [u] (abs (λ [v] (cond
+                                               (app (app equal (in 1)) w)
+                                               u v))))))))))
+
+;; Check if f is symmetrical
+(lp/addclause
+ '((prog "issym"
+         (abs (λ [f] (abs (λ [x] (abs (λ [y] (app
+                                              (app equal (app (app f x) y))
+                                              (app (app f y) x)))))))))))
+
+;; Calculate fibonacci (in a very costly fashion)
+(lp/addclause
+ '((prog "fib"
+         (fixpt (λ [fib]
+                   (abs (λ [n]
+                          (cond (app (app greater (in 2)) n) n
+                                (app (app plus
+                                          (app fib (app (app minus n) (in 1))))
+                                     (app fib (app (app minus n) (in 2))))
+                                ))))))))
+
+;; Calculate the factorial, in a tail-recursive fashion
+(lp/addclause
+ '((prog "fact"
+         (fixpt
+          (λ [f]
+             (abs
+              (λ [n]
+                 (abs
+                  (λ [m]
+                     (cond (app (app equal n) (in 0)) m
+                           (app (app f (app (app minus n) (in 1)))
+                                (app (app times n) m))))))))))))
+
+;; Good old map function
+(lp/addclause
+ '((prog "map"
+         (fixpt
+          (λ [map]
+             (abs
+              (λ [f]
+                 (abs
+                  (λ [l]
+                     (cond (app nullp l) ni
+                           (app (app cs (app f (app car l)))
+                                (app (app map f) (app cdr l)))))))))))))

--- a/samples/clj_lprolog/pcf/mono_test.clj
+++ b/samples/clj_lprolog/pcf/mono_test.clj
@@ -1,0 +1,16 @@
+(ns clj-lprolog.pcf.mono-test
+  (:require [clj-lprolog.core :as lp]))
+
+(load-file "samples/clj_lprolog/pcf/monoinfer.clj")
+(load-file "samples/clj_lprolog/pcf/examples.clj")
+
+(lp/defpred 'mono-test '(-> string ty o))
+
+(lp/addclause '((mono-test String Type) :- (prog String Term) (infer Term Type)))
+
+(lp/solve '(mono-test "successor" Ty))
+(lp/solve '(mono-test "onep" Ty))
+(lp/solve '(mono-test "issym" Ty))
+(lp/solve '(mono-test "fib" Ty))
+(lp/solve '(mono-test "fact" Ty))
+(lp/solve '(mono-test "map" Ty))

--- a/samples/clj_lprolog/pcf/monoinfer.clj
+++ b/samples/clj_lprolog/pcf/monoinfer.clj
@@ -1,0 +1,43 @@
+(ns clj-lprolog.pcf.monoinfer
+  (:require [clj-lprolog.core :as lp]))
+
+(load-file "samples/clj_lprolog/pcf/pcf.clj")
+(load-file "samples/clj_lprolog/pcf/monotypes.clj")
+
+;;{
+;; Inferring monotypes for programs
+;;}
+
+(lp/defpred 'prim '(-> tm ty o)) ;; Type of a primitive
+(lp/defpred 'infer '(-> tm ty o)) ;; Type of a term
+
+(lp/addclause '((infer (app M N) B) :- (infer M (--> A B)) (infer N A)))
+(lp/addclause '((infer (abs M) (--> A B)) :-
+                (Π (x :> tm) (=> (infer x A) (infer (M x) B)))))
+(lp/addclause '((infer (fixpt M) A) :-
+                (Π (x :> tm) (=> (infer x A) (infer (M x) A)))))
+(lp/addclause '((infer (cond C T E) A) :-
+                (infer C bool) (infer T A) (infer E A)))
+(lp/addclause '((infer T A) :- (prim T A)))
+
+;; Boolean primitives
+(lp/addclause '((prim (ib B) bool)))
+(lp/addclause '((prim && (--> bool (--> bool bool)))))
+(lp/addclause '((prim || (--> bool (--> bool bool)))))
+
+;; Integer primitives
+(lp/addclause '((prim (in N) num)))
+(lp/addclause '((prim plus (--> num (--> num num)))))
+(lp/addclause '((prim minus (--> num (--> num num)))))
+(lp/addclause '((prim times (--> num (--> num num)))))
+(lp/addclause '((prim equal (--> num (--> num bool)))))
+(lp/addclause '((prim greater (--> num (--> num bool)))))
+(lp/addclause '((prim zerop (--> num bool))))
+
+;; List primitives
+(lp/addclause '((prim ni (lst A))))
+(lp/addclause '((prim cs (--> A (--> (lst A) (lst A))))))
+(lp/addclause '((prim car (--> (lst A) A))))
+(lp/addclause '((prim cdr (--> (lst A) (lst A)))))
+(lp/addclause '((prim nullp (--> (lst A) bool))))
+(lp/addclause '((prim consp (--> (lst A) bool))))

--- a/samples/clj_lprolog/pcf/monotypes.clj
+++ b/samples/clj_lprolog/pcf/monotypes.clj
@@ -1,0 +1,13 @@
+(ns clj-lprolog.pcf.monotypes
+  (:require [clj-lprolog.core :as lp]))
+
+;;{
+;; Encoding of types, without polymorphism
+;;}
+
+(lp/deftype 'ty)
+
+(lp/defconst '--> '(-> ty ty ty))
+(lp/defconst 'lst '(-> ty ty))
+(lp/defconst 'num 'ty)
+(lp/defconst 'bool 'ty)

--- a/samples/clj_lprolog/pcf/pcf.clj
+++ b/samples/clj_lprolog/pcf/pcf.clj
@@ -1,0 +1,35 @@
+(ns clj-lprolog.pcf.pcf
+  (:require [clj-lprolog.core :as lp]))
+
+;;{
+;; The types and constants needed to encode the terms in a simple
+;; functional programming language PCF
+;;}
+
+;; Terms
+(lp/deftype 'tm)
+
+(lp/defconst 'abs '(-> (-> tm tm) tm)) ;; Abstraction
+(lp/defconst 'app '(-> tm tm tm)) ;; Application
+(lp/defconst 'fixpt '(-> (-> tm tm) tm)) ;; Fixpoint
+(lp/defconst 'cond '(-> tm tm tm tm)) ;; Conditional
+
+;; Primitives
+(lp/defconst 'ib '(-> boolean tm)) ;; Embedding booleans into the language
+(lp/defconst '&& 'tm)
+(lp/defconst '|| 'tm)
+
+(lp/defconst 'in '(-> int tm)) ;; Embedding integers into the language
+(lp/defconst 'minus 'tm)
+(lp/defconst 'plus 'tm)
+(lp/defconst 'times 'tm)
+(lp/defconst 'equal 'tm)
+(lp/defconst 'greater 'tm)
+(lp/defconst 'zerop 'tm)
+
+(lp/defconst 'ni 'tm)
+(lp/defconst 'cs 'tm)
+(lp/defconst 'car 'tm)
+(lp/defconst 'cdr 'tm)
+(lp/defconst 'nullp 'tm)
+(lp/defconst 'consp 'tm)

--- a/samples/clj_lprolog/stlc.clj
+++ b/samples/clj_lprolog/stlc.clj
@@ -2,6 +2,7 @@
   (:require [clj-lprolog.core :as lp]))
 
 ;; Simply-Typed-Lambda-Calculus
+;; The more complete PCF language is available in the pcf/ folder
 
 ;; The terms are based on λProlog user terms
 (lp/deftype 'term)

--- a/src/clj_lprolog/core.clj
+++ b/src/clj_lprolog/core.clj
@@ -93,4 +93,4 @@
          (typ/elaborate-and-freevar-pred
           (deref progconsts) (deref progpreds) req) :as [_ req _]
          [:ko> 'typecheck-request {:req req}]
-         (sol/solve (deref progpreds) req)))
+         (sol/solve (deref progconsts) (deref progpreds) req)))

--- a/src/clj_lprolog/norm.clj
+++ b/src/clj_lprolog/norm.clj
@@ -231,7 +231,7 @@
 
 (defn literal?
   "Check if `t` is a litteral"
-  [t] (or (syn/string-lit? t) (syn/int-lit? t)))
+  [t] (or (syn/string-lit? t) (syn/int-lit? t) (syn/boolean-lit? t)))
 
 (example (literal? 42) => true)
 

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -183,20 +183,25 @@
 (defn parse-goal
   "Parse one of the goals `g` in a clause"
   [g] (cond
-        ;; The body is a pi-abstraction
+        ;; The goal is a pi-abstraction
         (syn/pi? g)
         (ok>
          (when (not (proper-typed-binding? (second g))))
          [:ko 'parse-goal {:goal g}]
          (parse-clause-body (nthrest g 2)) :as [_ body]
          [:ok (list 'Π (second g) body)])
-        ;; The body is an implication
+        ;; The goal is an implication
         (syn/imp? g)
         (ok>
          (parse-applied-pred (second g)) :as [_ hd]
          (parse-clause-body (nthrest g 2)) :as [_ body]
          [:ok (list '=> hd body)])
-        ;; The first term of the body is an applied predicate
+        ;; The goal is a print directive
+        (syn/print? g)
+        (ok>
+         (parse (second g)) :as [_ t]
+         [:ok (list 'print t)])
+        ;; The goal is an applied predicate
         (syn/applied-pred? g) (parse-applied-pred g)
         :else [:ko 'parse-goal {:goal g}]))
 

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -35,6 +35,7 @@
           (syn/free? t)
           (syn/string-lit? t)
           (syn/int-lit? t)
+          (syn/boolean-lit? t)
           (syn/primitive? t)
           (syn/user-const? t)
           (proper-lambda? t)
@@ -70,6 +71,7 @@
           (syn/prop-type? t)
           (syn/string-type? t)
           (syn/int-type? t)
+          (syn/boolean-type? t)
           (syn/user-type? t)
           (proper-arrow-type? t)
           (proper-applied-type-constructor? t)))
@@ -131,6 +133,7 @@
         (syn/free? t) [:ok t]
         (syn/string-lit? t) [:ok t]
         (syn/int-lit? t) [:ok t]
+        (syn/boolean-lit? t) [:ok t]
         (syn/primitive? t) [:ok t]
 
         (lambda? t)
@@ -233,7 +236,6 @@
 
 (defn user-const-dec?
   "Is `c` a well formed constant declaration with type `ty`"
-  [c ty] (and (symbol? c) (= (symbol (str/lower-case c)) c)
-              (proper-type? ty)))
+  [c ty] (and (syn/user-const? c) (proper-type? ty)))
 
 (example (user-const-dec? 'ni '(list A)) => true)

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -34,6 +34,7 @@
   [t] (or (syn/bound? t)
           (syn/free? t)
           (syn/string-lit? t)
+          (syn/int-lit? t)
           (syn/primitive? t)
           (syn/user-const? t)
           (proper-lambda? t)
@@ -66,8 +67,10 @@
 (defn proper-type?
   "Is `t` a proper type ?"
   [t] (or (syn/type-var? t)
-          (syn/prop-type? t)
           (syn/nat-type? t)
+          (syn/prop-type? t)
+          (syn/string-type? t)
+          (syn/int-type? t)
           (syn/user-type? t)
           (proper-arrow-type? t)
           (proper-applied-type-constructor? t)))
@@ -90,7 +93,7 @@
   "Is `t` a bound variable or a constant ?"
   [t] (and (symbol? t)
            (not (some #{t} syn/reserved))
-           (not= (symbol (str/capitalize t)) t)))
+           (= (symbol (str/lower-case t)) t)))
 
 (example (bound-or-const? 'x) => true)
 
@@ -128,6 +131,7 @@
 
         (syn/free? t) [:ok t]
         (syn/string-lit? t) [:ok t]
+        (syn/int-lit? t) [:ok t]
         (syn/primitive? t) [:ok t]
 
         (lambda? t)

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -67,7 +67,6 @@
 (defn proper-type?
   "Is `t` a proper type ?"
   [t] (or (syn/type-var? t)
-          (syn/nat-type? t)
           (syn/prop-type? t)
           (syn/string-type? t)
           (syn/int-type? t)

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -33,6 +33,7 @@
   "Is `t` a kernel term ?"
   [t] (or (syn/bound? t)
           (syn/free? t)
+          (syn/string-lit? t)
           (syn/primitive? t)
           (syn/user-const? t)
           (proper-lambda? t)
@@ -105,6 +106,7 @@
   "Is `t` a user term ?"
   [t] (or (bound-or-const? t)
           (syn/free? t)
+          (syn/string-lit? t)
           (syn/primitive? t)
           (lambda? t)
           (syn/application? t)))
@@ -125,7 +127,7 @@
           [:ok t])
 
         (syn/free? t) [:ok t]
-
+        (syn/string-lit? t) [:ok t]
         (syn/primitive? t) [:ok t]
 
         (lambda? t)

--- a/src/clj_lprolog/presyntax.clj
+++ b/src/clj_lprolog/presyntax.clj
@@ -201,6 +201,8 @@
         (ok>
          (parse (second g)) :as [_ t]
          [:ok (list 'print t)])
+        ;; The goal is a read directive
+        (syn/read? g) [:ok g]
         ;; The goal is an applied predicate
         (syn/applied-pred? g) (parse-applied-pred g)
         :else [:ko 'parse-goal {:goal g}]))

--- a/src/clj_lprolog/solve.clj
+++ b/src/clj_lprolog/solve.clj
@@ -25,13 +25,13 @@
 (defn instantiate-term
   "Instantiate the term `t` by suffixing free-variables with `count`"
   [count t]
-  (with-meta
+  (typ/set-type
     (cond
       (syn/free? t) (instantiate-free-var count t)
       (syn/lambda? t) (list 'λ (second t) (instantiate-term count (nth t 2)))
       (syn/application? t) (map (fn [t] (instantiate-term count t)) t)
       :else t)
-    {:ty (typ/type-of t)}))
+    (typ/type-of t)))
 
 (defn instantiate-pred
   "Instantiate the predicate `p` by suffixing free-variables with `count`"
@@ -70,13 +70,13 @@
 (defn instantiatepi-term
   "Instantiate the term `t` by suffixing occurences of `x` with `count`"
   [x count t]
-  (with-meta
+  (typ/set-type
     (cond
       (and (syn/user-const? t) (= t x)) (instantiatepi-const count x)
       (syn/lambda? t) (list 'λ (second t) (instantiatepi-term x count (nth t 2)))
       (syn/application? t) (map (fn [t] (instantiatepi-term x count t)) t)
       :else t)
-    {:ty (typ/type-of t)}))
+    (typ/type-of t)))
 
 (defn instantiatepi-pred
   "Instantiate the predicate `p` by suffixing occurences of `x` with `count`"

--- a/src/clj_lprolog/solve.clj
+++ b/src/clj_lprolog/solve.clj
@@ -164,14 +164,14 @@
 
 (defn solve-body
   "Solve the clause body `b` in the context of the program `prog`"
-  [prog [si req] cnt]
+  [consts prog [si req] cnt]
   (cond (empty? req) [:ok si]
         ;; Pi-abstraction : instantiate the constants with a fresh identifier
         (syn/pi? (first req))
         (ok> (first (second (first req))) :as x
              (instantiatepi-clause-body x cnt (nth (first req) 2)) :as req1
              (rest req) :as req2
-             (solve-body prog [si (concat req1 req2)] (inc cnt)))
+             (solve-body consts prog [si (concat req1 req2)] (inc cnt)))
         ;; Implication : add a dynamic clause to the program
         (syn/imp? (first req))
         (ok> (second (first req)) :as assump
@@ -180,23 +180,31 @@
              (get prog (first assump)) :as [ty clauses]
              (cons [assump '()] clauses) :as clauses
              (assoc prog (first assump) [ty clauses]) :as prog
-             (solve-body prog [si (concat req1 req2)] (inc cnt)))
+             (solve-body consts prog [si (concat req1 req2)] (inc cnt)))
         ;; Print : well, print the term (after applying substitution)
         (syn/print? (first req))
         (ok> (second (first req)) :as t
              (println (uni/apply-subst si t))
-             (solve-body prog [si (rest req)] cnt))
+             (solve-body consts prog [si (rest req)] cnt))
+        ;; Read : read a term from the user, type-check it and use it
+        (syn/read? (first req))
+        (ok> (second (first req)) :as v
+             (read) :as t
+             (typ/check-and-elaborate-term consts t (typ/type-of v)) :as [_ t]
+             [:ko> 'typecheck-read {:t t}]
+             (uni/compose-subst si {v t}) :as [_ si]
+             (solve-body consts prog [si (rest req)] cnt))
         ;; Solve an applied predicate
-        (syn/applied-pred? (first req)) (solve prog [si req] cnt)))
+        (syn/applied-pred? (first req)) (solve consts prog [si req] cnt)))
 
 (defn solve
   "Solve `req` in the context of the program `prog`"
-  ([prog req]
-   (ok> (solve-body prog [{} (list req)] 0) :as [_ subst]
+  ([consts prog req]
+   (ok> (solve-body consts prog [{} (list req)] 0) :as [_ subst]
         (uni/get-freevars req) :as freevars
         [:ok (u/map-of-pair-list
               (map (fn [x] [x (uni/apply-subst subst x)]) freevars))]))
-  ([prog [si req] cnt]
+  ([consts prog [si req] cnt]
    (ok>
     ;; Let's try to solve the first constraint
     (uni/apply-subst si (first req)) :as scrut
@@ -211,12 +219,12 @@
     ;; Recursive calls (return the first correct one)
     (some
      (fn [[si cl]]
-       (let [res (solve-body prog [si (concat cl (rest req))] cnt)]
+       (let [res (solve-body consts prog [si (concat cl (rest req))] cnt)]
          (when (u/ok-expr? res) (second res))))
      poss) :as ress
     (when (nil? ress) [:ko 'solve {:req req}])
     [:ok ress])))
 
 (example
- (solve '{even [(-> nat o) {(even zero) (), (even (succ (succ N))) ((even N))}]}
+ (solve {} '{even [(-> nat o) {(even zero) (), (even (succ (succ N))) ((even N))}]}
        '(even (succ (succ (succ N))))) => '[:ok {N (succ zero)}])

--- a/src/clj_lprolog/solve.clj
+++ b/src/clj_lprolog/solve.clj
@@ -174,13 +174,18 @@
              (solve-body prog [si (concat req1 req2)] (inc cnt)))
         ;; Implication : add a dynamic clause to the program
         (syn/imp? (first req))
-        (ok> (uni/apply-subst si (second (first req))) :as assump
+        (ok> (second (first req)) :as assump
              (nth (first req) 2) :as req1
              (rest req) :as req2
              (get prog (first assump)) :as [ty clauses]
              (cons [assump '()] clauses) :as clauses
              (assoc prog (first assump) [ty clauses]) :as prog
              (solve-body prog [si (concat req1 req2)] (inc cnt)))
+        ;; Print : well, print the term (after applying substitution)
+        (syn/print? (first req))
+        (ok> (second (first req)) :as t
+             (println (uni/apply-subst si t))
+             (solve-body prog [si (rest req)] cnt))
         ;; Solve an applied predicate
         (syn/applied-pred? (first req)) (solve prog [si req] cnt)))
 

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -12,6 +12,7 @@
 ;; - a bound variable (identified by its De Bruijn index)
 ;; - a free (substituable) variable (identified by a symbol)
 ;; - a string literal
+;; - an int literal
 ;; - a constant (O, S, +, *, or user-declared)
 ;; - a n-ary λ-abstraction
 ;; - a n-ary application
@@ -20,7 +21,7 @@
 
 (def reserved
   "Reserved symbols"
-  '(λ ∀ => O S + *))
+  '(λ O S + *))
 
 (defn bound?
   "Is `t` a bound variable ?"
@@ -31,19 +32,26 @@
 (defn free?
   "Is `t` a free variable ?"
   [t] (and (symbol? t) (= (symbol (str/capitalize t)) t)
+           (Character/isLetter (first (str t)))
            (not (some #{t} reserved))))
 
 (example (free? 'A) => true)
 
 (defn string-lit?
-  "Is `t` a string litteral ?"
+  "Is `t` a string literal ?"
   [t] (string? t))
 
 (example (string-lit? "hello") => true)
 
+(defn int-lit?
+  "Is `t` an integer literal ?"
+  [t] (int? t))
+
+(example (int-lit? 42) => true)
+
 (defn primitive?
   "Is `t` a primitive constant ?"
-  [t] (some? (some #{t} (nthrest reserved 2))))
+  [t] (some? (some #{t} (rest reserved))))
 
 (examples
  (primitive? 'S) => true
@@ -92,6 +100,7 @@
 ;; - a type variable (identified by an capitalized symbol)
 ;; - the primitive "nat" type `i`
 ;; - the primitive "prop" type `o`
+;; - the primitive "int" type `int`
 ;; - the primitive "string" type `string`
 ;; - a user type
 ;; - a n-ary arrow type
@@ -114,6 +123,12 @@
   [t] (= t 'o))
 
 (example (prop-type? 'o) => true)
+
+(defn int-type?
+  "Is `t` the int type ?"
+  [t] (= t 'int))
+
+(example (int-type? 'int) => true)
 
 (defn string-type?
   "Is `t` the string type ?"

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -21,7 +21,7 @@
 
 (def primitives
   "Primitives of the language"
-  '(+ *))
+  '(+ - * quot mod))
 
 (def reserved
   "Reserved symbols"

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -13,6 +13,7 @@
 ;; - a free (substituable) variable (identified by a symbol)
 ;; - a string literal
 ;; - an int literal
+;; - a boolean literal (true or false)
 ;; - a constant (O, S, +, *, or user-declared)
 ;; - a n-ary λ-abstraction
 ;; - a n-ary application
@@ -21,7 +22,10 @@
 
 (def primitives
   "Primitives of the language"
-  '(+ - * quot mod))
+  '(+ - * quot mod
+      and or
+      = not=
+      zero? <= < >= >))
 
 (def reserved
   "Reserved symbols"
@@ -53,6 +57,12 @@
 
 (example (int-lit? 42) => true)
 
+(defn boolean-lit?
+  "Is `t` a boolean literal ?"
+  [t] (boolean? t))
+
+(example (boolean-lit? true) => true)
+
 (defn primitive?
   "Is `t` a primitive constant ?"
   [t] (some? (some #{t} primitives)))
@@ -61,7 +71,8 @@
 
 (defn user-const?
   "Is `t` a user constant ?"
-  [t] (and (symbol? t) (= (symbol (str/lower-case t)) t)))
+  [t] (and (symbol? t) (= (symbol (str/lower-case t)) t)
+           (not (some #{t} reserved))))
 
 (example (user-const? 'zero) => true)
 
@@ -103,6 +114,7 @@
 ;; - the primitive "prop" type `o`
 ;; - the primitive "int" type `int`
 ;; - the primitive "string" type `string`
+;; - the primitive "boolean" type `boolean`
 ;; - a user type
 ;; - a n-ary arrow type
 ;;}
@@ -124,6 +136,12 @@
   [t] (= t 'int))
 
 (example (int-type? 'int) => true)
+
+(defn boolean-type?
+  "Is `t` the boolean type ?"
+  [t] (= t 'boolean))
+
+(example (boolean-type? 'boolean) => true)
 
 (defn string-type?
   "Is `t` the string type ?"
@@ -202,7 +220,7 @@
 
 (defn pred?
   "Is `t` a predicate (either defined or free variable) ?"
-  [t] (symbol? t))
+  [t] (and (symbol? t) (not (some #{t} reserved))))
 
 (example (pred? 'even) => true)
 

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -19,9 +19,13 @@
 ;; - a suspension (used for explicit substitutions)
 ;;}
 
+(def primitives
+  "Primitives of the language"
+  '(+ *))
+
 (def reserved
   "Reserved symbols"
-  '(λ O S + *))
+  (concat '(λ) primitives))
 
 (defn bound?
   "Is `t` a bound variable ?"
@@ -51,11 +55,9 @@
 
 (defn primitive?
   "Is `t` a primitive constant ?"
-  [t] (some? (some #{t} (rest reserved))))
+  [t] (some? (some #{t} primitives)))
 
-(examples
- (primitive? 'S) => true
- (primitive? '+) => true)
+(example (primitive? '+) => true)
 
 (defn user-const?
   "Is `t` a user constant ?"
@@ -98,7 +100,6 @@
 ;;
 ;; A type is either
 ;; - a type variable (identified by an capitalized symbol)
-;; - the primitive "nat" type `i`
 ;; - the primitive "prop" type `o`
 ;; - the primitive "int" type `int`
 ;; - the primitive "string" type `string`
@@ -111,12 +112,6 @@
   [t] (and (symbol? t) (= (symbol (str/capitalize t)) t)))
 
 (example (type-var? 'A) => true)
-
-(defn nat-type?
-  "Is `t` the nat type ?"
-  [t] (= t 'i))
-
-(example (nat-type? 'i) => true)
 
 (defn prop-type?
   "Is `t` the proposition type ?"

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -11,6 +11,7 @@
 ;; A kernel lambda-term is either:
 ;; - a bound variable (identified by its De Bruijn index)
 ;; - a free (substituable) variable (identified by a symbol)
+;; - a string literal
 ;; - a constant (O, S, +, *, or user-declared)
 ;; - a n-ary λ-abstraction
 ;; - a n-ary application
@@ -33,6 +34,12 @@
            (not (some #{t} reserved))))
 
 (example (free? 'A) => true)
+
+(defn string-lit?
+  "Is `t` a string litteral ?"
+  [t] (string? t))
+
+(example (string-lit? "hello") => true)
 
 (defn primitive?
   "Is `t` a primitive constant ?"
@@ -85,6 +92,7 @@
 ;; - a type variable (identified by an capitalized symbol)
 ;; - the primitive "nat" type `i`
 ;; - the primitive "prop" type `o`
+;; - the primitive "string" type `string`
 ;; - a user type
 ;; - a n-ary arrow type
 ;;}
@@ -106,6 +114,12 @@
   [t] (= t 'o))
 
 (example (prop-type? 'o) => true)
+
+(defn string-type?
+  "Is `t` the string type ?"
+  [t] (= t 'string))
+
+(example (string-type? 'string) => true)
 
 (defn user-type?
   "Is `t` a user type ?"

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -247,6 +247,10 @@
   "Is `t` a print directive ?"
   [t] (and (seq? t) (= (count t) 2) (= 'print (first t))))
 
+(defn read?
+  "Is `t` a read directive ?"
+  [t] (and (seq? t) (= (count t) 2) (= 'read (first t)) (free? (second t))))
+
 (defn clause-body?
   "Is `t` a clause body ?"
   [t] (and (seq? t) (not (empty? t))))

--- a/src/clj_lprolog/syntax.clj
+++ b/src/clj_lprolog/syntax.clj
@@ -216,6 +216,7 @@
 ;; - An applied predicate
 ;; - A pi abstraction : Π (x :> ty) body
 ;; - An implication : p => body
+;; - A print directive : print t
 ;;}
 
 (defn pred?
@@ -241,6 +242,10 @@
   [t] (and (seq? t) (> (count t) 2) (= 'Π (first t))))
 
 (example (pi? '(Π (x :> term) (=> (infer x A) (infer (M x) B)))) => true)
+
+(defn print?
+  "Is `t` a print directive ?"
+  [t] (and (seq? t) (= (count t) 2) (= 'print (first t))))
 
 (defn clause-body?
   "Is `t` a clause body ?"

--- a/src/clj_lprolog/typecheck.clj
+++ b/src/clj_lprolog/typecheck.clj
@@ -14,7 +14,6 @@
 (defn valid-type?
   "Check that `ty` is built from primitive and user-defined types"
   [types ty] (cond
-               (syn/nat-type? ty) :ok
                (syn/prop-type? ty) :ok
                (syn/string-type? ty) :ok
                (syn/int-type? ty) :ok
@@ -30,7 +29,7 @@
                  [:ko 'check-type {:ty ty}])
                ))
 
-(example (valid-type? '#{bool} '(-> i bool)) => :ok)
+(example (valid-type? '#{bool} '(-> int bool)) => :ok)
 
 (defn check-const
   "Check that the constant `c` use types declared in `types`"
@@ -184,7 +183,7 @@
 
 (def primitive-env
   "Types of primitives"
-  { 'O 'i 'S '(-> i i) '+ '(-> i i i) '* '(-> i i i) })
+  { '+ '(-> int int int) '* '(-> int int int) })
 
 (defn rename-type-vars
   "Change the type variables in `ty` into type-unification variables
@@ -299,10 +298,10 @@
         [:ok ty])))
 
 (examples
- (infer-term '+) => [:ok '(-> i i i)]
+ (infer-term '+) => [:ok '(-> int int int)]
  (infer-term '(λ 2 #{0})) => [:ok '(-> Ty0 Ty1 Ty1)]
  (infer-term '((λ 2 #{1}) (λ 1 #{0}))) => [:ok '(-> Ty1 Ty2 Ty2)]
- (infer-term '((λ 1 #{0}) (S O))) => [:ok 'i])
+ (infer-term '((λ 1 #{0}) 0)) => [:ok 'int])
 
 (defn apply-subst-metadata
   "Apply a substitution `si` in the metadata of `t`"
@@ -469,8 +468,9 @@
        [:ok t vars]))
 
 (example
- (elaborate-and-freevar-pred {} {'even ['(-> i o)]} '(even (S N)))
- => [:ok '(even (S N)) {'N 'i}])
+ (elaborate-and-freevar-pred '{succ (-> int int)} {'even ['(-> int o)]}
+                             '(even (succ N)))
+ => [:ok '(even (succ N)) {'N 'int}])
 
 (declare check-freevar-clause-body)
 
@@ -514,9 +514,9 @@
        [:ok c vars]))
 
 (example
- (elaborate-and-freevar-clause {} {} {'even ['(-> i o)]}
-                               ['(even (S (S N))) '((even N))]) =>
- [:ok ['(even (S (S N))) '((even N))] {'N 'i}])
+ (elaborate-and-freevar-clause {} '{succ (-> int int)} {'even ['(-> int o)]}
+                               ['(even (succ (succ N))) '((even N))]) =>
+ [:ok ['(even (succ (succ N))) '((even N))] {'N 'int}])
 
 (defn elaborate-program
   "Elaborate the whole program `prog`"

--- a/src/clj_lprolog/typecheck.clj
+++ b/src/clj_lprolog/typecheck.clj
@@ -17,6 +17,7 @@
                (syn/nat-type? ty) :ok
                (syn/prop-type? ty) :ok
                (syn/string-type? ty) :ok
+               (syn/int-type? ty) :ok
                (syn/user-type? ty)
                (if (contains? types ty) :ok [:ko 'check-type {:ty ty}])
                (syn/arrow-type? ty)
@@ -201,12 +202,14 @@
   "Retrieve type information for an elaborated term `t`"
   [t] (cond
         (syn/string-lit? t) 'string
+        (syn/int-lit? t) 'int
         :else (get (meta t) :ty)))
 
 (defn set-type
   "Set the type information for a term `t`"
   [t ty] (cond
            (syn/string-lit? t) t
+           (syn/int-lit? t) t
            :else (with-meta t {:ty ty})))
 
 (defn subst-infer-term
@@ -236,6 +239,9 @@
 
      ;; t is a string literal
      (syn/string-lit? t) [:ok {} 'string t cnt]
+
+     ;; t is an integer literal
+     (syn/int-lit? t) [:ok {} 'int t cnt]
 
      ;; t is a primitive
      (syn/primitive? t)

--- a/src/clj_lprolog/typecheck.clj
+++ b/src/clj_lprolog/typecheck.clj
@@ -183,7 +183,8 @@
 
 (def primitive-env
   "Types of primitives"
-  { '+ '(-> int int int) '* '(-> int int int) })
+  '{ + (-> int int int) - (-> int int int) * (-> int int int)
+    quot (-> int int int) mod (-> int int int) })
 
 (defn rename-type-vars
   "Change the type variables in `ty` into type-unification variables

--- a/src/clj_lprolog/typecheck.clj
+++ b/src/clj_lprolog/typecheck.clj
@@ -429,6 +429,11 @@
     (ok>
      (elaborate-term consts (second g) cnt) :as [_ t cnt]
      [:ok (list 'print t) cnt])
+    ;; The goal is a read directive
+    (syn/read? g)
+    (ok>
+     (elaborate-term consts (second g) cnt) :as [_ t cnt]
+     [:ok (list 'read t) cnt])
     ;; The goal is an applied predicate
     (syn/applied-pred? g) (elaborate-pred consts prog g cnt)
     ;; Either a non well-formed term, or we forgot to implement something :p
@@ -507,6 +512,10 @@
     (syn/print? g)
     (ok> (get-freevar-types (second g)) :as [_ fvt2]
          (combine-env fvt fvt2))
+    ;; The goal is a read directive
+    (syn/read? g)
+    (ok> (get-freevar-types (second g)) :as [_ fvt2]
+         (combine-env fvt fvt2))
     ;; The goal is an applied predicate
     (syn/applied-pred? g)
     (ok> (check-freevar-pred g) :as [_ fvt2]
@@ -556,6 +565,8 @@
                    (apply-freevar-types-clause-body vars (nth g 2)))
              (syn/print? g)
              (list 'print (apply-freevar-types vars (second g)))
+             (syn/read? g)
+             (list 'read (apply-freevar-types vars (second g)))
              (syn/applied-pred? g) (apply-freevar-types vars g)))
 
 (defn apply-freevar-types-clause-body

--- a/src/clj_lprolog/typecheck.clj
+++ b/src/clj_lprolog/typecheck.clj
@@ -114,7 +114,7 @@
 (defn compose-subst
   "Compose two substitutions `s1` and `s2`, after checking that they dont clash"
   [s1 s2] (ok> (when (subst-clash? s1 s2) [:ko> 'subst-clash {:s1 s1 :s2 s2}])
-               [:ok (conj s1 (apply-subst-subst s1 s2))]))
+               [:ok (conj (apply-subst-subst s2 s1) (apply-subst-subst s1 s2))]))
 
 (examples
  (compose-subst {'ty1 'i} {'ty2 'o}) =>

--- a/src/clj_lprolog/unif.clj
+++ b/src/clj_lprolog/unif.clj
@@ -68,8 +68,10 @@
 
 (defn compose-subst
   "Compose two substitutions `s1` and `s2`, after checking that they dont clash"
-  [s1 s2] (ok> (when (subst-clash? s1 s2) [:ko> 'subst-clash {:s1 s1 :s2 s2}])
-               [:ok (conj (apply-subst-subst s2 s1) (apply-subst-subst s1 s2))]))
+  [s1 s2]
+  (ok> (when (subst-clash? s1 s2) [:ko> 'subst-clash {:s1 s1 :s2 s2}])
+       (conj (apply-subst-subst s2 s1) (apply-subst-subst s1 s2)) :as subst
+       [:ok subst]))
 
 (defn compose-subst-sets
   "Compose the sets of substitutions `s1` and `s2`.
@@ -92,7 +94,9 @@
   without occur-check"
   [substs]
   (set (filter
-        (fn [si] (not (some (fn [[v t]] (some #{v} (get-freevars t))) (seq si))))
+        (fn [si] (not (some (fn [[v t]]
+                             (and (not= v t)
+                                  (some #{v} (get-freevars t)))) (seq si))))
         substs)))
 
 ;;{

--- a/src/clj_lprolog/unif.clj
+++ b/src/clj_lprolog/unif.clj
@@ -46,7 +46,7 @@
               (typ/type-of t))))
 
 (example
- (subst 'A '(S O) '((λ 2 A) A B)) => '((λ 2 (S O)) (S O) B))
+ (subst 'A 42 '((λ 2 A) A B)) => '((λ 2 42) 42 B))
 
 (defn apply-subst
   "Apply a substitution `si` to a type `ty`"
@@ -272,8 +272,8 @@
                     (normal-form-arg e2 (second t2) (typ/type-of t2))])
                  (map vector (tail t1) (tail t2)))) subst))))))
 
-(example (simpl '([(λ 0 (A)) (λ 0 (S))] [(λ 2 (A (B))) (λ 2 (A #{1}))])) =>
-         '[:ok ([(λ 2 (B)) (λ 2 (#{1}))]) {A S}])
+(example (simpl '([(λ 0 (A)) (λ 0 (succ))] [(λ 2 (A (B))) (λ 2 (A #{1}))])) =>
+         '[:ok ([(λ 2 (B)) (λ 2 (#{1}))]) {A succ}])
 
 (defn fresh-unknown [count] (symbol (str "H" count)))
 

--- a/src/clj_lprolog/unif.clj
+++ b/src/clj_lprolog/unif.clj
@@ -50,7 +50,8 @@
 
 (defn apply-subst
   "Apply a substitution `si` to a type `ty`"
-  [si term] (reduce (fn [term [var t]] (subst var t term)) term si))
+  [si term] (nor/simplify-term
+             (reduce (fn [term [var t]] (subst var t term)) term si)))
 
 (defn subst-clash?
   "Check if there is a clash between `s1` and `s2`"
@@ -64,7 +65,7 @@
 (defn apply-subst-subst
   "Apply `s1` to every value of `s2`"
   [s1 s2] (u/map-of-pair-list
-           (map (fn [[k term]] [k (nor/simplify-term (apply-subst s1 term))]) s2)))
+           (map (fn [[k term]] [k (apply-subst s1 term)]) s2)))
 
 (defn compose-subst
   "Compose two substitutions `s1` and `s2`, after checking that they dont clash"

--- a/test/clj_lprolog/core_test.clj
+++ b/test/clj_lprolog/core_test.clj
@@ -35,23 +35,25 @@
 (t/deftest defpred-test
   (t/testing "even"
     (do (lp/start)
-        (lp/defpred 'even '(-> i o))
-        (t/is (= @lp/progpreds {'even ['(-> i o) '()]}))))
+        (lp/defpred 'even '(-> int o))
+        (t/is (= @lp/progpreds {'even ['(-> int o) '()]}))))
   (t/testing "even and odd"
     (do (lp/start)
-        (lp/defpred 'even '(-> i o))
-        (lp/defpred 'odd '(-> i o))
+        (lp/defpred 'even '(-> int o))
+        (lp/defpred 'odd '(-> int o))
         (t/is (= (get @lp/progpreds 'even) (get @lp/progpreds 'odd))))))
 
 (t/deftest addclause-test
   (t/testing "even"
     (do (lp/start)
-        (lp/defpred 'even '(-> i o))
-        (lp/addclause '((even O)))
-        (lp/addclause '((even (S (S N))) :- (even N)))
-        (t/is (= @lp/progpreds {'even ['(-> i o)
-                                        '([(even O) ()]
-                                          [(even (S (S N))) ((even N))])]}))))
+        (lp/defconst 'succ '(-> int int))
+        (lp/defpred 'even '(-> int o))
+        (lp/addclause '((even 0)))
+        (lp/addclause '((even (succ (succ N))) :- (even N)))
+        (t/is (= {'even ['(-> int o)
+                         '([(even 0) ()]
+                           [(even (succ (succ N))) ((even N))])]}
+              @lp/progpreds))))
   (t/testing "is the identity"
     (do
       (lp/start)

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -60,8 +60,17 @@
 
 ;; Tests on normalization
 
+(t/deftest evaluable?-test
+  (t/testing "positive"
+    (t/is (nor/evaluable? '(+ 3 4)))
+    (t/is (nor/evaluable? '(* (+ 1 2) (+ 3 4)))))
+  (t/testing "negative"
+    (t/is (not (nor/evaluable? '(+ 3 A))))
+    (t/is (not (nor/evaluable? (second (typ/elaborate-term {} '(+ 3))))))))
+
 (t/deftest simplify-term-test
   (t/is (= 'S (nor/simplify-term '(λ 0 (λ 0 S)))))
+  (t/is (= 12 (nor/simplify-term '((λ 1 (+ 5 #{0})) 7))))
   (t/is (= 'S (nor/simplify-term '(((((((((((((((((((S)))))))))))))))))))))))
 
 (t/deftest lift-indices-test

--- a/test/clj_lprolog/norm_test.clj
+++ b/test/clj_lprolog/norm_test.clj
@@ -71,11 +71,12 @@
   (t/is (= '((λ 1 #{2}) #{1}) (nor/lift-indices 1 '((λ 1 #{1}) #{0})))))
 
 (defn eta
-  [t] (nor/norm-eta (second (typ/elaborate-term {} t))))
+  [t] (nor/norm-eta (second (typ/elaborate-term '{succ (-> int int)} t))))
 
 (t/deftest norm-eta-test
   (t/is (= '(λ 2 #{0}) (eta '(λ 2 #{0}))))
-  (t/is (= '(λ 1 (S #{0})) (eta '(λ 0 S))))
+  (t/is (= '(λ 1 (succ #{0}))
+           (eta '(λ 0 succ))))
   (t/is (= '(λ 3 ((λ 2 (S #{0})) #{1} #{0})) (eta '(λ 1 (λ 2 (S #{0})))))))
 
 (defn normalize

--- a/test/clj_lprolog/presyntax_test.clj
+++ b/test/clj_lprolog/presyntax_test.clj
@@ -90,6 +90,11 @@
     (t/is (not (syn/user-type-dec? '(list (list A)))))
     (t/is (not (syn/user-type-dec? '(pair a b))))))
 
+(t/deftest parse-goal-test
+  (t/is (u/ok-expr? (syn/parse-goal '(even O))))
+  (t/is (u/ok-expr? (syn/parse-goal '(Π (n :> i) (=> (P n) (P (S (S n))))))))
+  (t/is (u/ok-expr? (syn/parse-goal '(print (λ [x] x))))))
+
 (t/deftest parse-clause-test
   (t/testing "positive"
     (t/is (u/ok-expr? (syn/parse-clause '((even O)))))

--- a/test/clj_lprolog/presyntax_test.clj
+++ b/test/clj_lprolog/presyntax_test.clj
@@ -24,7 +24,8 @@
   (t/is (syn/proper-kernel-term? #{1}))
   (t/is (syn/proper-kernel-term? 'A))
   (t/is (syn/proper-kernel-term? '(λ 2 (#{1} #{2}))))
-  (t/is (syn/proper-kernel-term? '(A B))))
+  (t/is (syn/proper-kernel-term? '(A B)))
+  (t/is (syn/proper-kernel-term? '(print "hello world"))))
 
 ;; Tests on proper type syntax
 

--- a/test/clj_lprolog/solve_test.clj
+++ b/test/clj_lprolog/solve_test.clj
@@ -44,12 +44,12 @@
 (t/deftest solve-test
   (t/testing "oddeven"
     (t/is (= '[:ok {N (succ zero)}]
-             (sol/solve
+             (sol/solve {}
               '{even [(-> nat o) {(even zero) (),
                                   (even (succ (succ N))) ((even N))}]}
               '(even (succ (succ (succ N)))))))
     (t/is (= '[:ok {N zero}]
-             (sol/solve
+             (sol/solve {}
               '{even [(-> nat o) {(even zero) (),
                                   (even (succ N)) ((odd N))}]
                 odd [(-> nat o) {(odd (succ zero)) (),
@@ -57,18 +57,20 @@
               '(even (succ (succ N)))))))
   (t/testing "lists"
     (t/is (u/ok-expr?
-           (sol/solve listsprog '(member zero (cs X (cs Y ni))))))
+           (sol/solve {} listsprog '(member zero (cs X (cs Y ni))))))
     (t/is (u/ko-expr?
-           (sol/solve listsprog
+           (sol/solve {} listsprog
                       '(member (succ zero) (cs zero (cs zero ni))))))
     (t/is (u/ok-expr?
-           (sol/solve listsprog
+           (sol/solve {} listsprog
                       '(append (cs zero ni) L (cs zero (cs (succ zero) ni))))))
     (t/is (u/ko-expr?
-           (sol/solve listsprog '(append (cs zero ni) L L))))
+           (sol/solve {} listsprog '(append (cs zero ni) L L))))
     (t/is (u/ok-expr?
-           (sol/solve listsprog '(reverse (cs (succ zero) (cs zero ni))
-                                          (cs zero (cs (succ zero) ni))))))
+           (sol/solve {} listsprog
+                      '(reverse (cs (succ zero) (cs zero ni))
+                                (cs zero (cs (succ zero) ni))))))
     (t/is (u/ko-expr?
-           (sol/solve listsprog '(reverse (cs (succ zero) (cs (zero ni)))
-                                          (cs (succ zero) (cs (zero ni)))))))))
+           (sol/solve {} listsprog
+                      '(reverse (cs (succ zero) (cs (zero ni)))
+                                (cs (succ zero) (cs (zero ni)))))))))

--- a/test/clj_lprolog/syntax_test.clj
+++ b/test/clj_lprolog/syntax_test.clj
@@ -123,9 +123,16 @@
 
 (t/deftest print?-test
   (t/testing "positive"
-    (t/is (syn/print? '(print A))))
+    (t/is (syn/print? '(print (λ [x] x)))))
   (t/testing "negative"
     (t/is (not (syn/print? '(prin A))))))
+
+(t/deftest read?-test
+  (t/testing "positive"
+    (t/is (syn/read? '(read A))))
+  (t/testing "negative"
+    (t/is (not (syn/read? '(rea A))))
+    (t/is (not (syn/read? '(read (λ [x] x)))))))
 
 (t/deftest clause-body?-test
   (t/testing "positive"

--- a/test/clj_lprolog/syntax_test.clj
+++ b/test/clj_lprolog/syntax_test.clj
@@ -121,6 +121,12 @@
   (t/testing "negative"
     (t/is (not (syn/applied-pred? '(() O))))))
 
+(t/deftest print?-test
+  (t/testing "positive"
+    (t/is (syn/print? '(print A))))
+  (t/testing "negative"
+    (t/is (not (syn/print? '(prin A))))))
+
 (t/deftest clause-body?-test
   (t/testing "positive"
     (t/is (syn/clause-body? '((even N))))

--- a/test/clj_lprolog/syntax_test.clj
+++ b/test/clj_lprolog/syntax_test.clj
@@ -23,13 +23,11 @@
   (t/testing "positive"
     (t/is (syn/free? 'A)))
   (t/testing "negative"
-    (t/is (not (syn/free? 'S)))
     (t/is (not (syn/free? 12)))
     (t/is (not (syn/free? ())))))
 
 (t/deftest primitive?-test
   (t/testing "positive"
-    (t/is (syn/primitive? 'S))
     (t/is (syn/primitive? '+)))
   (t/testing "negative"
     (t/is (not (syn/primitive? '∀)))
@@ -63,13 +61,6 @@
   (t/testing "negative"
     (t/is (not (syn/type-var? 'a)))
     (t/is (not (syn/type-var? '())))))
-
-(t/deftest nat-type?-test
-  (t/testing "positive"
-    (t/is (syn/nat-type? 'i)))
-  (t/testing "negative"
-    (t/is (not (syn/nat-type? 'I)))
-    (t/is (not (syn/nat-type? '())))))
 
 (t/deftest prop-type?-test
   (t/testing "positive"

--- a/test/clj_lprolog/typecheck_test.clj
+++ b/test/clj_lprolog/typecheck_test.clj
@@ -146,7 +146,7 @@
                (nth
                 (typ/elaborate-and-freevar-clause
                  #{} '{succ (-> int int)} (deref cor/progpreds)
-                 '((even (succ N)) ((odd N)))) 2)))))
+                 '((even (succ N)) ((print N) (odd N)))) 2)))))
   (t/testing "pred"
     (do
       (cor/start)

--- a/test/clj_lprolog/typecheck_test.clj
+++ b/test/clj_lprolog/typecheck_test.clj
@@ -48,6 +48,8 @@
     (t/is (u/ok-expr? (typ/subst-infer-term {} #{0} ['i] 0)))
     (t/is (= [:ok 'i] (typ/infer-term '(S (S (S O))))))
     (t/is (= [:ok 'nat] (typ/infer-term {'zero 'nat} 'zero)))
+    (t/is (= [:ok 'string] (typ/infer-term {} "hello")))
+    (t/is (= [:ok 'int] (typ/infer-term {} 42)))
     (t/is (= [:ok 'nat] (typ/infer-term {'succ '(-> nat nat)} '(succ N))))
     (t/is (= [:ok '(-> i i)] (typ/infer-term '(+ (* (S O) (S O))))))
     (t/is (u/ok-expr? (typ/infer-term '(λ 1 #{0}))))

--- a/test/clj_lprolog/typecheck_test.clj
+++ b/test/clj_lprolog/typecheck_test.clj
@@ -178,7 +178,8 @@
   (t/testing "positive"
     (t/is (= :ok (typ/valid-type? '#{bool} 'bool)))
     (t/is (= :ok (typ/valid-type? '#{bool} 'i)))
-    (t/is (= :ok (typ/valid-type? '#{bool} '(-> i i bool)))))
+    (t/is (= :ok (typ/valid-type? '#{bool} '(-> i i bool))))
+    (t/is (= :ok (typ/valid-type? '#{} '(-> string o)))))
   (t/testing "negative"
     (t/is (u/ko-expr? (typ/valid-type? #{} '(-> i bool))))))
 

--- a/test/clj_lprolog/unif_test.clj
+++ b/test/clj_lprolog/unif_test.clj
@@ -46,7 +46,7 @@
   (t/testing "negative"
     (t/is (not (uni/unif-var? '(λ 1 (A)))))
     (t/is (not (uni/unif-var? '(λ 0 (A B)))))
-    (t/is (not (uni/unif-var? '(λ 0 (O)))))))
+    (t/is (not (uni/unif-var? '(λ 0 (0)))))))
 
 (t/deftest trivial-test
   (t/is (= '() (uni/trivial '([(λ 0 (#{0})) (λ 0 (A))]))))
@@ -58,7 +58,7 @@
   (t/testing "positive"
     (t/is (= '[:ok () {A zero}] (uni/simpl '([(λ 0 (zero)) (λ 0 (A))]))))
     (t/is (= '[:ok ([(λ 2 (A)) (λ 2 (#{1}))]) {}]
-             (uni/simpl '([(λ 2 (S A)) (λ 2 (S #{1}))])))))
+             (uni/simpl '([(λ 2 (succ A)) (λ 2 (succ #{1}))])))))
   (t/testing "negative"
     (t/is (u/ko-expr? (uni/simpl '([(λ 2 (#{0})) (λ 2 (#{1}))]))))))
 


### PR DESCRIPTION
Je suis en train d'implémenter le support pour les types de bases (et des opérations qui vont avec) de clojure dans le langage. Cela permet lors de l'unification d'un terme de réduire automatiquement `(+ 1 2)` à `3` par exemple. L'utilisateur peut donc utiliser des littéraux dans son programme, et bien sur la vérification de types leur donne le type correspondant. Pour le moment j'ai implémenté:
- le type `int` avec les opérations arithmétiques de base
- le type `bool` avec les comparaisons d'entiers et les opérations logiques de base
- le type `string` sans aucune opération pour le moment

Je me pose par contre une question: est-il utile d'implémenter dans les primitives le type `list` (avec `nil` et `cons`) sachant qu'il peut aisément être décrit par un type utilisateur avec deux constructeurs (je sais que c'est aussi le cas pour le type `bool`, mais j'avais besoin de mettre les comparaisons d'entiers dans les primitives).
Question subsiduaire : si cela vaut le coup d'implémenter le type `list` dans les types primitifs, comment décrire des littéraux de listes; en effet les listes clojure sont déjà utilisées pour décrire les applications, donc ça risque de poser un souci. Devrai-je alors utiliser les vecteurs ? Y'a-t-il une différence de performances quand on les manipule avec `cons`, `first` et `rest` ?
Merci aux experts de clojure pour leurs conseils !

Par ailleurs je me suis aussi servi de tout ça pour mettre en place un interpréteur (et inférence de type) pour le langage PCF qui fait partie des exemples un peu plus développées de Teyjus. Ca a l'air de marcher sans bug, par contre c'est carrément lent...